### PR TITLE
If bug corrections and enhancements

### DIFF
--- a/src/Automatonymous.Tests/Condition_Specs.cs
+++ b/src/Automatonymous.Tests/Condition_Specs.cs
@@ -44,6 +44,15 @@ namespace Automatonymous.Tests
             Assert.That(_instance.CurrentState, Is.Not.EqualTo(_machine.ShouldNotBeHere));
         }
 
+        [Test]
+        public async Task Should_evaluate_else_statement_when_if_condition__is_false()
+        {
+            await _machine.RaiseEvent(_instance, _machine.ExplicitFilterStarted, new StartedExplicitFilter());
+
+            Assert.That(_instance.ShouldBeCalled, Is.True);
+        }
+        
+
         [SetUp]
         public void Specifying_an_event_activity()
         {
@@ -59,6 +68,8 @@ namespace Automatonymous.Tests
         {
             public bool InitializeOnly { get; set; }
             public State CurrentState { get; set; }
+            
+            public bool ShouldBeCalled { get; set; }
         }
 
 
@@ -75,10 +86,13 @@ namespace Automatonymous.Tests
 
                 During(Initial,
                     When(ExplicitFilterStarted, context => true)
-                        .If(context => false, binder => binder
-                            .Then(context => Console.WriteLine("Should not be here!"))
-                            .TransitionTo(ShouldNotBeHere))
-                        .If(context => true, binder => binder.Then(context => Console.WriteLine("Initializing Only!"))));
+                        .IfElse(context => false, 
+                            binder => binder
+                                .Then(context => Console.WriteLine("Should not be here!"))
+                                .TransitionTo(ShouldNotBeHere),
+                            binder => binder
+                                .Then(context => context.Instance.ShouldBeCalled = true)
+                                .Then(context => Console.WriteLine("Initializing Only!"))));
 
                 During(Running,
                     When(Finish)
@@ -136,6 +150,14 @@ namespace Automatonymous.Tests
             Assert.That(_instance.CurrentState, Is.Not.EqualTo(_machine.ShouldNotBeHere));
         }
 
+        [Test]
+        public async Task Should_evaluate_else_statement_when_if_condition__is_false()
+        {
+            await _machine.RaiseEvent(_instance, _machine.ExplicitFilterStarted, new StartedExplicitFilter());
+
+            Assert.That(_instance.ShouldBeCalled, Is.True);
+        }
+
         [SetUp]
         public void Specifying_an_event_activity()
         {
@@ -151,6 +173,7 @@ namespace Automatonymous.Tests
         {
             public bool InitializeOnly { get; set; }
             public State CurrentState { get; set; }
+            public bool ShouldBeCalled { get; set; }
         }
 
 
@@ -167,10 +190,13 @@ namespace Automatonymous.Tests
 
                 During(Initial,
                     When(ExplicitFilterStarted, context => true)
-                        .IfAsync(context => Task.FromResult(false), binder => binder
-                            .Then(context => Console.WriteLine("Should not be here!"))
-                            .TransitionTo(ShouldNotBeHere))
-                        .IfAsync(context => Task.FromResult(true), binder => binder.Then(context => Console.WriteLine("Initializing Only!"))));
+                        .IfElseAsync(context => Task.FromResult(false), 
+                            binder => binder
+                                .Then(context => Console.WriteLine("Should not be here!"))
+                                .TransitionTo(ShouldNotBeHere),
+                            binder => binder
+                                .Then(context => context.Instance.ShouldBeCalled = true)
+                                .Then(context => Console.WriteLine("Initializing Only!"))));
 
                 During(Running,
                     When(Finish)

--- a/src/Automatonymous.Tests/Condition_Specs.cs
+++ b/src/Automatonymous.Tests/Condition_Specs.cs
@@ -108,4 +108,96 @@ namespace Automatonymous.Tests
         {
         }
     }
+
+    [TestFixture]
+    public class Using_an_async_condition_in_a_state_machine
+    {
+        [Test]
+        public async Task Should_allow_the_condition_to_be_used()
+        {
+            await _machine.RaiseEvent(_instance, _machine.Started, new Start {InitializeOnly = true});
+
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Initialized));
+        }
+
+        [Test]
+        public async Task Should_work()
+        {
+            await _machine.RaiseEvent(_instance, _machine.Started, new Start());
+
+            Assert.That(_instance.CurrentState, Is.EqualTo(_machine.Running));
+        }
+
+        [Test]
+        public async Task Should_allow_if_condition_to_be_evaluated()
+        {
+            await _machine.RaiseEvent(_instance, _machine.ExplicitFilterStarted, new StartedExplicitFilter());
+
+            Assert.That(_instance.CurrentState, Is.Not.EqualTo(_machine.ShouldNotBeHere));
+        }
+
+        [SetUp]
+        public void Specifying_an_event_activity()
+        {
+            _instance = new Instance();
+            _machine = new InstanceStateMachine();
+        }
+
+        Instance _instance;
+        InstanceStateMachine _machine;
+
+
+        class Instance
+        {
+            public bool InitializeOnly { get; set; }
+            public State CurrentState { get; set; }
+        }
+
+
+        class InstanceStateMachine :
+            AutomatonymousStateMachine<Instance>
+        {
+            public InstanceStateMachine()
+            {
+                During(Initial,
+                    When(Started)
+                        .Then(context => context.Instance.InitializeOnly = context.Data.InitializeOnly)
+                        .IfAsync(context => Task.FromResult(context.Data.InitializeOnly), x => x.Then(context => Console.WriteLine("Initializing Only!")))
+                        .TransitionTo(Initialized));
+
+                During(Initial,
+                    When(ExplicitFilterStarted, context => true)
+                        .IfAsync(context => Task.FromResult(false), binder => binder
+                            .Then(context => Console.WriteLine("Should not be here!"))
+                            .TransitionTo(ShouldNotBeHere))
+                        .IfAsync(context => Task.FromResult(true), binder => binder.Then(context => Console.WriteLine("Initializing Only!"))));
+
+                During(Running,
+                    When(Finish)
+                        .Finalize());
+
+                WhenEnter(Initialized, x => x.IfAsync(context => Task.FromResult(!context.Instance.InitializeOnly), b => b.TransitionTo(Running)));
+            }
+
+            public State Running { get; private set; }
+            public State Initialized { get; private set; }
+            public State ShouldNotBeHere { get; private set; }
+
+            public Event<Start> Started { get; private set; }
+            public Event<StartedExplicitFilter> ExplicitFilterStarted { get; private set; }
+
+            public Event Finish { get; private set; }
+        }
+
+
+        class Start
+        {
+            public bool InitializeOnly { get; set; }
+        }
+
+
+        class StartedExplicitFilter
+        {
+        }
+    }
 }

--- a/src/Automatonymous.Tests/Exception_Specs.cs
+++ b/src/Automatonymous.Tests/Exception_Specs.cs
@@ -51,7 +51,12 @@ namespace Automatonymous.Tests
             public bool ShouldNotBeCalled { get; set; }
 
             public bool CalledThenClause { get; set; }
-            public bool CalledSecondThenClause { get; set; }
+            public bool CalledThenClauseAsync { get; set; }
+
+            public bool ThenShouldNotBeCalled { get; set; }
+            public bool ElseShouldBeCalled { get; set; }
+            public bool ThenAsyncShouldNotBeCalled { get; set; }
+            public bool ElseAsyncShouldBeCalled { get; set; }
         }
 
 
@@ -70,7 +75,15 @@ namespace Automatonymous.Tests
                                 .Then(context => context.Instance.CalledThenClause = true)
                             )
                             .IfAsync(context => Task.FromResult(true), b => b
-                                .Then(context => context.Instance.CalledSecondThenClause = true)
+                                .Then(context => context.Instance.CalledThenClauseAsync = true)
+                            )
+                            .IfElse(context => false, 
+                                b => b.Then(context => context.Instance.ThenShouldNotBeCalled = true),
+                                b => b.Then(context => context.Instance.ElseShouldBeCalled = true)
+                            )
+                            .IfElseAsync(context => Task.FromResult(false), 
+                                b => b.Then(context => context.Instance.ThenAsyncShouldNotBeCalled = true),
+                                b => b.Then(context => context.Instance.ElseAsyncShouldBeCalled = true)
                             )
                             .Then(context =>
                             {
@@ -142,7 +155,31 @@ namespace Automatonymous.Tests
         [Test]
         public void Should_have_called_the_async_if_block()
         {
-            Assert.IsTrue(_instance.CalledSecondThenClause);
+            Assert.IsTrue(_instance.CalledThenClauseAsync);
+        }
+
+        [Test]
+        public void Should_not_have_called_the_false_condition_then_block()
+        {
+            Assert.IsFalse(_instance.ThenShouldNotBeCalled);
+        }
+
+        [Test]
+        public void Should_not_have_called_the_false_async_condition_then_block()
+        {
+            Assert.IsFalse(_instance.ThenAsyncShouldNotBeCalled);
+        }
+
+        [Test]
+        public void Should_have_called_the_false_condition_else_block()
+        {
+            Assert.IsTrue(_instance.ElseShouldBeCalled);
+        }
+
+        [Test]
+        public void Should_have_called_the_false_async_condition_else_block()
+        {
+            Assert.IsTrue(_instance.ElseAsyncShouldBeCalled);
         }
     }
 
@@ -316,6 +353,11 @@ namespace Automatonymous.Tests
 
             public bool CalledThenClause { get; set; }
             public bool CalledSecondThenClause { get; set; }
+
+            public bool ThenShouldNotBeCalled { get; set; }
+            public bool ElseShouldBeCalled { get; set; }
+            public bool ThenAsyncShouldNotBeCalled { get; set; }
+            public bool ElseAsyncShouldBeCalled { get; set; }
         }
 
 
@@ -342,6 +384,14 @@ namespace Automatonymous.Tests
                             )
                             .IfAsync(context => Task.FromResult(true), b => b
                                 .Then(context => context.Instance.CalledSecondThenClause = true)
+                            )
+                            .IfElse(context => false, 
+                                b => b.Then(context => context.Instance.ThenShouldNotBeCalled = true),
+                                b => b.Then(context => context.Instance.ElseShouldBeCalled = true)
+                            )
+                            .IfElseAsync(context => Task.FromResult(false), 
+                                b => b.Then(context => context.Instance.ThenAsyncShouldNotBeCalled = true),
+                                b => b.Then(context => context.Instance.ElseAsyncShouldBeCalled = true)
                             )
                             .Then(context =>
                             {
@@ -398,5 +448,30 @@ namespace Automatonymous.Tests
         {
             Assert.IsTrue(_instance.CalledSecondThenClause);
         }
+
+        [Test]
+        public void Should_not_have_called_the_false_condition_then_block()
+        {
+            Assert.IsFalse(_instance.ThenShouldNotBeCalled);
+        }
+
+        [Test]
+        public void Should_not_have_called_the_false_async_condition_then_block()
+        {
+            Assert.IsFalse(_instance.ThenAsyncShouldNotBeCalled);
+        }
+
+        [Test]
+        public void Should_have_called_the_false_condition_else_block()
+        {
+            Assert.IsTrue(_instance.ElseShouldBeCalled);
+        }
+
+        [Test]
+        public void Should_have_called_the_false_async_condition_else_block()
+        {
+            Assert.IsTrue(_instance.ElseAsyncShouldBeCalled);
+        }
     }
+
 }

--- a/src/Automatonymous.Tests/Exception_Specs.cs
+++ b/src/Automatonymous.Tests/Exception_Specs.cs
@@ -48,6 +48,8 @@ namespace Automatonymous.Tests
             public State CurrentState { get; set; }
 
             public bool ShouldNotBeCalled { get; set; }
+
+            public bool CalledThenClause { get; set; }
         }
 
 
@@ -62,6 +64,9 @@ namespace Automatonymous.Tests
                         .Then(_ => { throw new ApplicationException("Boom!"); })
                         .Then(context => context.Instance.NotCalled = false)
                         .Catch<ApplicationException>(ex => ex
+                            .If(context => true, b => b
+                                .Then(context => context.Instance.CalledThenClause = true)
+                            )
                             .Then(context =>
                             {
                                 context.Instance.ExceptionMessage = context.Exception.Message;
@@ -121,6 +126,12 @@ namespace Automatonymous.Tests
         public void Should_not_have_called_the_second_action()
         {
             Assert.IsTrue(_instance.NotCalled);
+        }
+
+        [Test]
+        public void Should_have_called_the_first_if_block()
+        {
+            Assert.IsTrue(_instance.CalledThenClause);
         }
     }
 
@@ -291,6 +302,8 @@ namespace Automatonymous.Tests
             public Type ExceptionType { get; set; }
             public string ExceptionMessage { get; set; }
             public State CurrentState { get; set; }
+
+            public bool CalledThenClause { get; set; }
         }
 
 
@@ -312,13 +325,15 @@ namespace Automatonymous.Tests
                         .Then(_ => { throw new ApplicationException("Boom!"); })
                         .Then(context => context.Instance.NotCalled = false)
                         .Catch<Exception>(ex => ex
+                            .If(context => true, b => b
+                                .Then(context => context.Instance.CalledThenClause = true)
+                            )
                             .Then(context =>
                             {
                                 context.Instance.ExceptionMessage = context.Exception.Message;
                                 context.Instance.ExceptionType = context.Exception.GetType();
                             })
                             .TransitionTo(Failed)));
-                
             }
 
             public State Failed { get; private set; }
@@ -355,6 +370,12 @@ namespace Automatonymous.Tests
         public void Should_not_have_called_the_second_action()
         {
             Assert.IsTrue(_instance.NotCalled);
+        }
+
+        [Test]
+        public void Should_have_called_the_first_if_block()
+        {
+            Assert.IsTrue(_instance.CalledThenClause);
         }
     }
 }

--- a/src/Automatonymous.Tests/Exception_Specs.cs
+++ b/src/Automatonymous.Tests/Exception_Specs.cs
@@ -13,6 +13,7 @@
 namespace Automatonymous.Tests
 {
     using System;
+    using System.Threading.Tasks;
     using GreenPipes;
     using GreenPipes.Introspection;
     using NUnit.Framework;
@@ -50,6 +51,7 @@ namespace Automatonymous.Tests
             public bool ShouldNotBeCalled { get; set; }
 
             public bool CalledThenClause { get; set; }
+            public bool CalledSecondThenClause { get; set; }
         }
 
 
@@ -66,6 +68,9 @@ namespace Automatonymous.Tests
                         .Catch<ApplicationException>(ex => ex
                             .If(context => true, b => b
                                 .Then(context => context.Instance.CalledThenClause = true)
+                            )
+                            .IfAsync(context => Task.FromResult(true), b => b
+                                .Then(context => context.Instance.CalledSecondThenClause = true)
                             )
                             .Then(context =>
                             {
@@ -132,6 +137,12 @@ namespace Automatonymous.Tests
         public void Should_have_called_the_first_if_block()
         {
             Assert.IsTrue(_instance.CalledThenClause);
+        }
+
+        [Test]
+        public void Should_have_called_the_async_if_block()
+        {
+            Assert.IsTrue(_instance.CalledSecondThenClause);
         }
     }
 
@@ -304,6 +315,7 @@ namespace Automatonymous.Tests
             public State CurrentState { get; set; }
 
             public bool CalledThenClause { get; set; }
+            public bool CalledSecondThenClause { get; set; }
         }
 
 
@@ -327,6 +339,9 @@ namespace Automatonymous.Tests
                         .Catch<Exception>(ex => ex
                             .If(context => true, b => b
                                 .Then(context => context.Instance.CalledThenClause = true)
+                            )
+                            .IfAsync(context => Task.FromResult(true), b => b
+                                .Then(context => context.Instance.CalledSecondThenClause = true)
                             )
                             .Then(context =>
                             {
@@ -376,6 +391,12 @@ namespace Automatonymous.Tests
         public void Should_have_called_the_first_if_block()
         {
             Assert.IsTrue(_instance.CalledThenClause);
+        }
+
+        [Test]
+        public void Should_have_called_the_async_if_block()
+        {
+            Assert.IsTrue(_instance.CalledSecondThenClause);
         }
     }
 }

--- a/src/Automatonymous/Activities/ConditionActivity.cs
+++ b/src/Automatonymous/Activities/ConditionActivity.cs
@@ -21,9 +21,9 @@ namespace Automatonymous.Activities
         where TInstance : class
     {
         readonly Behavior<TInstance> _behavior;
-        readonly StateMachineCondition<TInstance> _condition;
+        readonly StateMachineAsyncCondition<TInstance> _condition;
 
-        public ConditionActivity(StateMachineCondition<TInstance> condition, Behavior<TInstance> behavior)
+        public ConditionActivity(StateMachineAsyncCondition<TInstance> condition, Behavior<TInstance> behavior)
         {
             _condition = condition;
             _behavior = behavior;
@@ -43,7 +43,7 @@ namespace Automatonymous.Activities
 
         async Task Activity<TInstance>.Execute(BehaviorContext<TInstance> context, Behavior<TInstance> next)
         {
-            if (_condition(context))
+            if (await _condition(context).ConfigureAwait(false))
                 await _behavior.Execute(context).ConfigureAwait(false);
 
             await next.Execute(context).ConfigureAwait(false);
@@ -51,7 +51,7 @@ namespace Automatonymous.Activities
 
         async Task Activity<TInstance>.Execute<T>(BehaviorContext<TInstance, T> context, Behavior<TInstance, T> next)
         {
-            if (_condition(context))
+            if (await _condition(context).ConfigureAwait(false))
                 await _behavior.Execute(context).ConfigureAwait(false);
 
             await next.Execute(context).ConfigureAwait(false);
@@ -75,9 +75,9 @@ namespace Automatonymous.Activities
         where TInstance : class
     {
         readonly Behavior<TInstance> _behavior;
-        readonly StateMachineCondition<TInstance, TData> _condition;
+        readonly StateMachineAsyncCondition<TInstance, TData> _condition;
 
-        public ConditionActivity(StateMachineCondition<TInstance, TData> condition, Behavior<TInstance> behavior)
+        public ConditionActivity(StateMachineAsyncCondition<TInstance, TData> condition, Behavior<TInstance> behavior)
         {
             _condition = condition;
             _behavior = behavior;
@@ -105,7 +105,7 @@ namespace Automatonymous.Activities
             var behaviorContext = context as BehaviorContext<TInstance, TData>;
             if (behaviorContext != null)
             {
-                if (_condition(behaviorContext))
+                if (await _condition(behaviorContext).ConfigureAwait(false))
                     await _behavior.Execute(behaviorContext).ConfigureAwait(false);
             }
 

--- a/src/Automatonymous/Activities/ConditionActivity.cs
+++ b/src/Automatonymous/Activities/ConditionActivity.cs
@@ -20,31 +20,37 @@ namespace Automatonymous.Activities
         Activity<TInstance>
         where TInstance : class
     {
-        readonly Behavior<TInstance> _behavior;
+        readonly Behavior<TInstance> _thenBehavior;
+        readonly Behavior<TInstance> _elseBehavior;
         readonly StateMachineAsyncCondition<TInstance> _condition;
 
-        public ConditionActivity(StateMachineAsyncCondition<TInstance> condition, Behavior<TInstance> behavior)
+        public ConditionActivity(StateMachineAsyncCondition<TInstance> condition, Behavior<TInstance> thenBehavior, Behavior<TInstance> elseBehavior)
         {
             _condition = condition;
-            _behavior = behavior;
+            _thenBehavior = thenBehavior;
+            _elseBehavior = elseBehavior;
         }
 
         void IProbeSite.Probe(ProbeContext context)
         {
             var scope = context.CreateScope("condition");
 
-            _behavior.Probe(scope);
+            _thenBehavior.Probe(scope);
+            _elseBehavior.Probe(scope);
         }
 
         void Visitable.Accept(StateMachineVisitor visitor)
         {
-            visitor.Visit(this, x => _behavior.Accept(visitor));
+            visitor.Visit(this, x => _thenBehavior.Accept(visitor));
+            visitor.Visit(this, x => _elseBehavior.Accept(visitor));
         }
 
         async Task Activity<TInstance>.Execute(BehaviorContext<TInstance> context, Behavior<TInstance> next)
         {
             if (await _condition(context).ConfigureAwait(false))
-                await _behavior.Execute(context).ConfigureAwait(false);
+                await _thenBehavior.Execute(context).ConfigureAwait(false);
+            else
+                await _elseBehavior.Execute(context).ConfigureAwait(false);
 
             await next.Execute(context).ConfigureAwait(false);
         }
@@ -52,7 +58,9 @@ namespace Automatonymous.Activities
         async Task Activity<TInstance>.Execute<T>(BehaviorContext<TInstance, T> context, Behavior<TInstance, T> next)
         {
             if (await _condition(context).ConfigureAwait(false))
-                await _behavior.Execute(context).ConfigureAwait(false);
+                await _thenBehavior.Execute(context).ConfigureAwait(false);
+            else
+                await _elseBehavior.Execute(context).ConfigureAwait(false);
 
             await next.Execute(context).ConfigureAwait(false);
         }
@@ -74,25 +82,29 @@ namespace Automatonymous.Activities
         Activity<TInstance>
         where TInstance : class
     {
-        readonly Behavior<TInstance> _behavior;
+        readonly Behavior<TInstance> _thenBehavior;
+        readonly Behavior<TInstance> _elseBehavior;
         readonly StateMachineAsyncCondition<TInstance, TData> _condition;
 
-        public ConditionActivity(StateMachineAsyncCondition<TInstance, TData> condition, Behavior<TInstance> behavior)
+        public ConditionActivity(StateMachineAsyncCondition<TInstance, TData> condition, Behavior<TInstance> thenBehavior, Behavior<TInstance> elseBehavior)
         {
             _condition = condition;
-            _behavior = behavior;
+            _thenBehavior = thenBehavior;
+            _elseBehavior = elseBehavior;
         }
 
         void IProbeSite.Probe(ProbeContext context)
         {
             var scope = context.CreateScope("condition");
 
-            _behavior.Probe(scope);
+            _thenBehavior.Probe(scope);
+            _elseBehavior.Probe(scope);
         }
 
         void Visitable.Accept(StateMachineVisitor visitor)
         {
-            visitor.Visit(this, x => _behavior.Accept(visitor));
+            visitor.Visit(this, x => _thenBehavior.Accept(visitor));
+            visitor.Visit(this, x => _elseBehavior.Accept(visitor));
         }
 
         Task Activity<TInstance>.Execute(BehaviorContext<TInstance> context, Behavior<TInstance> next)
@@ -106,7 +118,9 @@ namespace Automatonymous.Activities
             if (behaviorContext != null)
             {
                 if (await _condition(behaviorContext).ConfigureAwait(false))
-                    await _behavior.Execute(behaviorContext).ConfigureAwait(false);
+                    await _thenBehavior.Execute(behaviorContext).ConfigureAwait(false);
+                else
+                    await _elseBehavior.Execute(behaviorContext).ConfigureAwait(false);
             }
 
             await next.Execute(context).ConfigureAwait(false);

--- a/src/Automatonymous/Activities/ConditionExceptionActivity.cs
+++ b/src/Automatonymous/Activities/ConditionExceptionActivity.cs
@@ -1,0 +1,143 @@
+﻿// Copyright 2011-2016 Chris Patterson, Dru Sellers
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Automatonymous.Activities
+{
+    using System;
+    using System.Threading.Tasks;
+    using GreenPipes;
+
+
+    public class ConditionExceptionActivity<TInstance, TConditionException> :
+        Activity<TInstance>
+        where TInstance : class
+        where TConditionException : Exception
+    {
+        readonly Behavior<TInstance> _behavior;
+        readonly StateMachineExceptionCondition<TInstance, TConditionException> _condition;
+
+        public ConditionExceptionActivity(StateMachineExceptionCondition<TInstance, TConditionException> condition, Behavior<TInstance> behavior)
+        {
+            _condition = condition;
+            _behavior = behavior;
+        }
+
+        void IProbeSite.Probe(ProbeContext context)
+        {
+            var scope = context.CreateScope("condition");
+
+            _behavior.Probe(scope);
+        }
+
+        void Visitable.Accept(StateMachineVisitor visitor)
+        {
+            visitor.Visit(this, x => _behavior.Accept(visitor));
+        }
+
+        Task Activity<TInstance>.Execute(BehaviorContext<TInstance> context, Behavior<TInstance> next)
+        {
+            return next.Execute(context);
+        }
+
+        Task Activity<TInstance>.Execute<T>(BehaviorContext<TInstance, T> context, Behavior<TInstance, T> next)
+        {
+            return next.Execute(context);
+        }
+
+        async Task Activity<TInstance>.Faulted<TException>(BehaviorExceptionContext<TInstance, TException> context, Behavior<TInstance> next)
+        {
+            var behaviorContext = context as BehaviorExceptionContext<TInstance, TConditionException>;
+            if (behaviorContext != null)
+            {
+                if (_condition(behaviorContext))
+                {
+                    await _behavior.Faulted(context).ConfigureAwait(false);
+                }
+            }
+
+            await next.Faulted(context).ConfigureAwait(false);
+        }
+
+        async Task Activity<TInstance>.Faulted<T, TException>(BehaviorExceptionContext<TInstance, T, TException> context,
+            Behavior<TInstance, T> next)
+        {
+            var behaviorContext = context as BehaviorExceptionContext<TInstance, T, TConditionException>;
+            if (behaviorContext != null)
+            {
+                if (_condition(behaviorContext))
+                {
+                    await _behavior.Faulted(context).ConfigureAwait(false);
+                }
+            }
+
+            await next.Faulted(context).ConfigureAwait(false);
+        }
+    }
+
+
+    public class ConditionExceptionActivity<TInstance, TData, TConditionException> :
+        Activity<TInstance>
+        where TInstance : class
+        where TConditionException : Exception
+    {
+        readonly Behavior<TInstance> _behavior;
+        readonly StateMachineExceptionCondition<TInstance, TData, TConditionException> _condition;
+
+        public ConditionExceptionActivity(StateMachineExceptionCondition<TInstance, TData, TConditionException> condition, Behavior<TInstance> behavior)
+        {
+            _condition = condition;
+            _behavior = behavior;
+        }
+
+        void IProbeSite.Probe(ProbeContext context)
+        {
+            var scope = context.CreateScope("condition");
+
+            _behavior.Probe(scope);
+        }
+
+        void Visitable.Accept(StateMachineVisitor visitor)
+        {
+            visitor.Visit(this, x => _behavior.Accept(visitor));
+        }
+
+        Task Activity<TInstance>.Execute(BehaviorContext<TInstance> context, Behavior<TInstance> next)
+        {
+            throw new AutomatonymousException("This activity requires a body with the event, but no body was specified.");
+        }
+
+        Task Activity<TInstance>.Execute<T>(BehaviorContext<TInstance, T> context, Behavior<TInstance, T> next)
+        {
+            return next.Execute(context);
+        }
+
+        Task Activity<TInstance>.Faulted<TException>(BehaviorExceptionContext<TInstance, TException> context, Behavior<TInstance> next)
+        {
+            throw new AutomatonymousException("This activity requires a body with the event, but no body was specified.");
+        }
+
+        async Task Activity<TInstance>.Faulted<T, TException>(BehaviorExceptionContext<TInstance, T, TException> context,
+            Behavior<TInstance, T> next)
+        {
+            var behaviorContext = context as BehaviorExceptionContext<TInstance, TData, TConditionException>;
+            if (behaviorContext != null)
+            {
+                if (_condition(behaviorContext))
+                {
+                    await _behavior.Faulted(context).ConfigureAwait(false);
+                }
+            }
+
+            await next.Faulted(context).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Automatonymous/Activities/ConditionExceptionActivity.cs
+++ b/src/Automatonymous/Activities/ConditionExceptionActivity.cs
@@ -22,25 +22,30 @@ namespace Automatonymous.Activities
         where TInstance : class
         where TConditionException : Exception
     {
-        readonly Behavior<TInstance> _behavior;
+        readonly Behavior<TInstance> _thenBehavior;
+        readonly Behavior<TInstance> _elseBehavior;
         readonly StateMachineAsyncExceptionCondition<TInstance, TConditionException> _condition;
 
-        public ConditionExceptionActivity(StateMachineAsyncExceptionCondition<TInstance, TConditionException> condition, Behavior<TInstance> behavior)
+        public ConditionExceptionActivity(StateMachineAsyncExceptionCondition<TInstance, TConditionException> condition,
+            Behavior<TInstance> thenBehavior, Behavior<TInstance> elseBehavior)
         {
             _condition = condition;
-            _behavior = behavior;
+            _thenBehavior = thenBehavior;
+            _elseBehavior = elseBehavior;
         }
 
         void IProbeSite.Probe(ProbeContext context)
         {
             var scope = context.CreateScope("condition");
 
-            _behavior.Probe(scope);
+            _thenBehavior.Probe(scope);
+            _elseBehavior.Probe(scope);
         }
 
         void Visitable.Accept(StateMachineVisitor visitor)
         {
-            visitor.Visit(this, x => _behavior.Accept(visitor));
+            visitor.Visit(this, x => _thenBehavior.Accept(visitor));
+            visitor.Visit(this, x => _elseBehavior.Accept(visitor));
         }
 
         Task Activity<TInstance>.Execute(BehaviorContext<TInstance> context, Behavior<TInstance> next)
@@ -60,7 +65,11 @@ namespace Automatonymous.Activities
             {
                 if (await _condition(behaviorContext).ConfigureAwait(false))
                 {
-                    await _behavior.Faulted(context).ConfigureAwait(false);
+                    await _thenBehavior.Faulted(context).ConfigureAwait(false);
+                }
+                else
+                {
+                    await _elseBehavior.Faulted(context).ConfigureAwait(false);
                 }
             }
 
@@ -75,7 +84,11 @@ namespace Automatonymous.Activities
             {
                 if (await _condition(behaviorContext).ConfigureAwait(false))
                 {
-                    await _behavior.Faulted(context).ConfigureAwait(false);
+                    await _thenBehavior.Faulted(context).ConfigureAwait(false);
+                }
+                else
+                {
+                    await _elseBehavior.Faulted(context).ConfigureAwait(false);
                 }
             }
 
@@ -89,25 +102,30 @@ namespace Automatonymous.Activities
         where TInstance : class
         where TConditionException : Exception
     {
-        readonly Behavior<TInstance> _behavior;
+        readonly Behavior<TInstance> _thenBehavior;
+        readonly Behavior<TInstance> _elseBehavior;
         readonly StateMachineAsyncExceptionCondition<TInstance, TData, TConditionException> _condition;
 
-        public ConditionExceptionActivity(StateMachineAsyncExceptionCondition<TInstance, TData, TConditionException> condition, Behavior<TInstance> behavior)
+        public ConditionExceptionActivity(StateMachineAsyncExceptionCondition<TInstance, TData, TConditionException> condition,
+            Behavior<TInstance> thenBehavior, Behavior<TInstance> elseBehavior)
         {
             _condition = condition;
-            _behavior = behavior;
+            _thenBehavior = thenBehavior;
+            _elseBehavior = elseBehavior;
         }
 
         void IProbeSite.Probe(ProbeContext context)
         {
             var scope = context.CreateScope("condition");
 
-            _behavior.Probe(scope);
+            _thenBehavior.Probe(scope);
+            _elseBehavior.Probe(scope);
         }
 
         void Visitable.Accept(StateMachineVisitor visitor)
         {
-            visitor.Visit(this, x => _behavior.Accept(visitor));
+            visitor.Visit(this, x => _thenBehavior.Accept(visitor));
+            visitor.Visit(this, x => _elseBehavior.Accept(visitor));
         }
 
         Task Activity<TInstance>.Execute(BehaviorContext<TInstance> context, Behavior<TInstance> next)
@@ -133,7 +151,11 @@ namespace Automatonymous.Activities
             {
                 if (await _condition(behaviorContext).ConfigureAwait(false))
                 {
-                    await _behavior.Faulted(context).ConfigureAwait(false);
+                    await _thenBehavior.Faulted(context).ConfigureAwait(false);
+                }
+                else
+                {
+                    await _elseBehavior.Faulted(context).ConfigureAwait(false);
                 }
             }
 

--- a/src/Automatonymous/Activities/ConditionExceptionActivity.cs
+++ b/src/Automatonymous/Activities/ConditionExceptionActivity.cs
@@ -23,9 +23,9 @@ namespace Automatonymous.Activities
         where TConditionException : Exception
     {
         readonly Behavior<TInstance> _behavior;
-        readonly StateMachineExceptionCondition<TInstance, TConditionException> _condition;
+        readonly StateMachineAsyncExceptionCondition<TInstance, TConditionException> _condition;
 
-        public ConditionExceptionActivity(StateMachineExceptionCondition<TInstance, TConditionException> condition, Behavior<TInstance> behavior)
+        public ConditionExceptionActivity(StateMachineAsyncExceptionCondition<TInstance, TConditionException> condition, Behavior<TInstance> behavior)
         {
             _condition = condition;
             _behavior = behavior;
@@ -58,7 +58,7 @@ namespace Automatonymous.Activities
             var behaviorContext = context as BehaviorExceptionContext<TInstance, TConditionException>;
             if (behaviorContext != null)
             {
-                if (_condition(behaviorContext))
+                if (await _condition(behaviorContext).ConfigureAwait(false))
                 {
                     await _behavior.Faulted(context).ConfigureAwait(false);
                 }
@@ -73,7 +73,7 @@ namespace Automatonymous.Activities
             var behaviorContext = context as BehaviorExceptionContext<TInstance, T, TConditionException>;
             if (behaviorContext != null)
             {
-                if (_condition(behaviorContext))
+                if (await _condition(behaviorContext).ConfigureAwait(false))
                 {
                     await _behavior.Faulted(context).ConfigureAwait(false);
                 }
@@ -90,9 +90,9 @@ namespace Automatonymous.Activities
         where TConditionException : Exception
     {
         readonly Behavior<TInstance> _behavior;
-        readonly StateMachineExceptionCondition<TInstance, TData, TConditionException> _condition;
+        readonly StateMachineAsyncExceptionCondition<TInstance, TData, TConditionException> _condition;
 
-        public ConditionExceptionActivity(StateMachineExceptionCondition<TInstance, TData, TConditionException> condition, Behavior<TInstance> behavior)
+        public ConditionExceptionActivity(StateMachineAsyncExceptionCondition<TInstance, TData, TConditionException> condition, Behavior<TInstance> behavior)
         {
             _condition = condition;
             _behavior = behavior;
@@ -131,7 +131,7 @@ namespace Automatonymous.Activities
             var behaviorContext = context as BehaviorExceptionContext<TInstance, TData, TConditionException>;
             if (behaviorContext != null)
             {
-                if (_condition(behaviorContext))
+                if (await _condition(behaviorContext).ConfigureAwait(false))
                 {
                     await _behavior.Faulted(context).ConfigureAwait(false);
                 }

--- a/src/Automatonymous/Binders/CatchExceptionActivityBinder.cs
+++ b/src/Automatonymous/Binders/CatchExceptionActivityBinder.cs
@@ -81,7 +81,7 @@ namespace Automatonymous.Binders
 
             binder = activityCallback(binder);
 
-            var conditionBinder = new ConditionalActivityBinder<TInstance>(_event, condition, binder);
+            var conditionBinder = new ConditionalExceptionActivityBinder<TInstance, TException>(_event, condition, binder);
 
             return new CatchExceptionActivityBinder<TInstance, TException>(_machine, _event, _activities, conditionBinder);
         }
@@ -163,7 +163,7 @@ namespace Automatonymous.Binders
 
             binder = activityCallback(binder);
 
-            var conditionBinder = new ConditionalActivityBinder<TInstance, TData>(_event, condition, binder);
+            var conditionBinder = new ConditionalExceptionActivityBinder<TInstance, TData, TException>(_event, condition, binder);
 
             return new CatchExceptionActivityBinder<TInstance, TData, TException>(_machine, _event, _activities, conditionBinder);
         }

--- a/src/Automatonymous/Binders/CatchExceptionActivityBinder.cs
+++ b/src/Automatonymous/Binders/CatchExceptionActivityBinder.cs
@@ -74,7 +74,8 @@ namespace Automatonymous.Binders
             return new CatchExceptionActivityBinder<TInstance, TException>(_machine, _event, _activities, activityBinder);
         }
 
-        public ExceptionActivityBinder<TInstance, TException> If(StateMachineCondition<TInstance> condition,
+        public ExceptionActivityBinder<TInstance, TException> If(
+            StateMachineExceptionCondition<TInstance, TException> condition,
             Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> activityCallback)
         {
             ExceptionActivityBinder<TInstance, TException> binder = new CatchExceptionActivityBinder<TInstance, TException>(_machine, _event);
@@ -154,9 +155,8 @@ namespace Automatonymous.Binders
             return new CatchExceptionActivityBinder<TInstance, TData, TException>(_machine, _event, _activities, activityBinder);
         }
 
-        public ExceptionActivityBinder<TInstance, TData, TException> If(StateMachineCondition<TInstance, TData> condition,
-            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>>
-                activityCallback)
+        public ExceptionActivityBinder<TInstance, TData, TException> If(StateMachineExceptionCondition<TInstance, TData, TException> condition,
+            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> activityCallback)
         {
             ExceptionActivityBinder<TInstance, TData, TException> binder =
                 new CatchExceptionActivityBinder<TInstance, TData, TException>(_machine, _event);

--- a/src/Automatonymous/Binders/CatchExceptionActivityBinder.cs
+++ b/src/Automatonymous/Binders/CatchExceptionActivityBinder.cs
@@ -78,26 +78,44 @@ namespace Automatonymous.Binders
             StateMachineExceptionCondition<TInstance, TException> condition,
             Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> activityCallback)
         {
-            ExceptionActivityBinder<TInstance, TException> binder = new CatchExceptionActivityBinder<TInstance, TException>(_machine, _event);
-
-            binder = activityCallback(binder);
-
-            var conditionBinder = new ConditionalExceptionActivityBinder<TInstance, TException>(_event, condition, binder);
-
-            return new CatchExceptionActivityBinder<TInstance, TException>(_machine, _event, _activities, conditionBinder);
+            return IfElse(condition, activityCallback, _ => _);
         }
 
         public ExceptionActivityBinder<TInstance, TException> IfAsync(
             StateMachineAsyncExceptionCondition<TInstance, TException> condition,
             Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> activityCallback)
         {
-            ExceptionActivityBinder<TInstance, TException> binder = new CatchExceptionActivityBinder<TInstance, TException>(_machine, _event);
+            return IfElseAsync(condition, activityCallback, _ => _);
+        }
 
-            binder = activityCallback(binder);
-
-            var conditionBinder = new ConditionalExceptionActivityBinder<TInstance, TException>(_event, condition, binder);
+        public ExceptionActivityBinder<TInstance, TException> IfElse(StateMachineExceptionCondition<TInstance, TException> condition,
+            Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> thenActivityCallback,
+            Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> elseActivityCallback)
+        {
+            var thenBinder = GetBinder(thenActivityCallback);
+            var elseBinder = GetBinder(elseActivityCallback);
+            
+            var conditionBinder = new ConditionalExceptionActivityBinder<TInstance, TException>(_event, condition, thenBinder, elseBinder);
 
             return new CatchExceptionActivityBinder<TInstance, TException>(_machine, _event, _activities, conditionBinder);
+        }
+
+        public ExceptionActivityBinder<TInstance, TException> IfElseAsync(StateMachineAsyncExceptionCondition<TInstance, TException> condition,
+            Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> thenActivityCallback,
+            Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> elseActivityCallback)
+        {
+            var thenBinder = GetBinder(thenActivityCallback);
+            var elseBinder = GetBinder(elseActivityCallback);
+
+            var conditionBinder = new ConditionalExceptionActivityBinder<TInstance, TException>(_event, condition, thenBinder, elseBinder);
+
+            return new CatchExceptionActivityBinder<TInstance, TException>(_machine, _event, _activities, conditionBinder);
+        }
+
+        private ExceptionActivityBinder<TInstance, TException> GetBinder(Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> callback)
+        {
+            ExceptionActivityBinder<TInstance, TException> thenBinder = new CatchExceptionActivityBinder<TInstance, TException>(_machine, _event);
+            return callback(thenBinder);
         }
     }
 
@@ -171,27 +189,43 @@ namespace Automatonymous.Binders
         public ExceptionActivityBinder<TInstance, TData, TException> If(StateMachineExceptionCondition<TInstance, TData, TException> condition,
             Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> activityCallback)
         {
-            ExceptionActivityBinder<TInstance, TData, TException> binder =
-                new CatchExceptionActivityBinder<TInstance, TData, TException>(_machine, _event);
-
-            binder = activityCallback(binder);
-
-            var conditionBinder = new ConditionalExceptionActivityBinder<TInstance, TData, TException>(_event, condition, binder);
-
-            return new CatchExceptionActivityBinder<TInstance, TData, TException>(_machine, _event, _activities, conditionBinder);
+            return IfElse(condition, activityCallback, _ => _);
         }
 
         public ExceptionActivityBinder<TInstance, TData, TException> IfAsync(StateMachineAsyncExceptionCondition<TInstance, TData, TException> condition,
             Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> activityCallback)
         {
-            ExceptionActivityBinder<TInstance, TData, TException> binder =
-                new CatchExceptionActivityBinder<TInstance, TData, TException>(_machine, _event);
+            return IfElseAsync(condition, activityCallback, _ => _);
+        }
 
-            binder = activityCallback(binder);
+        public ExceptionActivityBinder<TInstance, TData, TException> IfElse(StateMachineExceptionCondition<TInstance, TData, TException> condition,
+            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> thenActivityCallback,
+            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> elseActivityCallback)
+        {
+            var thenBinder = GetBinder(thenActivityCallback);
+            var elseBinder = GetBinder(elseActivityCallback);
 
-            var conditionBinder = new ConditionalExceptionActivityBinder<TInstance, TData, TException>(_event, condition, binder);
+            var conditionBinder = new ConditionalExceptionActivityBinder<TInstance, TData, TException>(_event, condition, thenBinder, elseBinder);
 
             return new CatchExceptionActivityBinder<TInstance, TData, TException>(_machine, _event, _activities, conditionBinder);
+        }
+
+        public ExceptionActivityBinder<TInstance, TData, TException> IfElseAsync(StateMachineAsyncExceptionCondition<TInstance, TData, TException> condition,
+            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> thenActivityCallback,
+            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> elseActivityCallback)
+        {
+            var thenBinder = GetBinder(thenActivityCallback);
+            var elseBinder = GetBinder(elseActivityCallback);
+
+            var conditionBinder = new ConditionalExceptionActivityBinder<TInstance, TData, TException>(_event, condition, thenBinder, elseBinder);
+
+            return new CatchExceptionActivityBinder<TInstance, TData, TException>(_machine, _event, _activities, conditionBinder);
+        }
+
+        private ExceptionActivityBinder<TInstance, TData, TException> GetBinder(Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> callback)
+        {
+            ExceptionActivityBinder<TInstance, TData, TException> binder = new CatchExceptionActivityBinder<TInstance, TData, TException>(_machine, _event);
+            return callback(binder);
         }
     }
 }

--- a/src/Automatonymous/Binders/CatchExceptionActivityBinder.cs
+++ b/src/Automatonymous/Binders/CatchExceptionActivityBinder.cs
@@ -86,6 +86,19 @@ namespace Automatonymous.Binders
 
             return new CatchExceptionActivityBinder<TInstance, TException>(_machine, _event, _activities, conditionBinder);
         }
+
+        public ExceptionActivityBinder<TInstance, TException> IfAsync(
+            StateMachineAsyncExceptionCondition<TInstance, TException> condition,
+            Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> activityCallback)
+        {
+            ExceptionActivityBinder<TInstance, TException> binder = new CatchExceptionActivityBinder<TInstance, TException>(_machine, _event);
+
+            binder = activityCallback(binder);
+
+            var conditionBinder = new ConditionalExceptionActivityBinder<TInstance, TException>(_event, condition, binder);
+
+            return new CatchExceptionActivityBinder<TInstance, TException>(_machine, _event, _activities, conditionBinder);
+        }
     }
 
 
@@ -156,6 +169,19 @@ namespace Automatonymous.Binders
         }
 
         public ExceptionActivityBinder<TInstance, TData, TException> If(StateMachineExceptionCondition<TInstance, TData, TException> condition,
+            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> activityCallback)
+        {
+            ExceptionActivityBinder<TInstance, TData, TException> binder =
+                new CatchExceptionActivityBinder<TInstance, TData, TException>(_machine, _event);
+
+            binder = activityCallback(binder);
+
+            var conditionBinder = new ConditionalExceptionActivityBinder<TInstance, TData, TException>(_event, condition, binder);
+
+            return new CatchExceptionActivityBinder<TInstance, TData, TException>(_machine, _event, _activities, conditionBinder);
+        }
+
+        public ExceptionActivityBinder<TInstance, TData, TException> IfAsync(StateMachineAsyncExceptionCondition<TInstance, TData, TException> condition,
             Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> activityCallback)
         {
             ExceptionActivityBinder<TInstance, TData, TException> binder =

--- a/src/Automatonymous/Binders/ConditionalActivityBinder.cs
+++ b/src/Automatonymous/Binders/ConditionalActivityBinder.cs
@@ -12,6 +12,7 @@
 // specific language governing permissions and limitations under the License.
 namespace Automatonymous.Binders
 {
+    using System.Threading.Tasks;
     using Activities;
     using Behaviors;
 
@@ -21,10 +22,15 @@ namespace Automatonymous.Binders
         where TInstance : class
     {
         readonly EventActivities<TInstance> _activities;
-        readonly StateMachineCondition<TInstance> _condition;
+        readonly StateMachineAsyncCondition<TInstance> _condition;
         readonly Event _event;
 
         public ConditionalActivityBinder(Event @event, StateMachineCondition<TInstance> condition, EventActivities<TInstance> activities)
+            : this(@event, context => Task.FromResult(condition(context)), activities)
+        {
+        }
+
+        public ConditionalActivityBinder(Event @event, StateMachineAsyncCondition<TInstance> condition, EventActivities<TInstance> activities)
         {
             _activities = activities;
             _condition = condition;
@@ -72,10 +78,16 @@ namespace Automatonymous.Binders
         where TInstance : class
     {
         readonly EventActivities<TInstance> _activities;
-        readonly StateMachineCondition<TInstance, TData> _condition;
+        readonly StateMachineAsyncCondition<TInstance, TData> _condition;
         readonly Event _event;
 
         public ConditionalActivityBinder(Event @event, StateMachineCondition<TInstance, TData> condition,
+            EventActivities<TInstance> activities)
+            : this(@event, context => Task.FromResult(condition(context)), activities)
+        {
+        }
+
+        public ConditionalActivityBinder(Event @event, StateMachineAsyncCondition<TInstance, TData> condition,
             EventActivities<TInstance> activities)
         {
             _activities = activities;

--- a/src/Automatonymous/Binders/ConditionalActivityBinder.cs
+++ b/src/Automatonymous/Binders/ConditionalActivityBinder.cs
@@ -21,18 +21,24 @@ namespace Automatonymous.Binders
         ActivityBinder<TInstance>
         where TInstance : class
     {
-        readonly EventActivities<TInstance> _activities;
+        readonly EventActivities<TInstance> _thenActivities;
+        readonly EventActivities<TInstance> _elseActivities;
         readonly StateMachineAsyncCondition<TInstance> _condition;
         readonly Event _event;
 
-        public ConditionalActivityBinder(Event @event, StateMachineCondition<TInstance> condition, EventActivities<TInstance> activities)
-            : this(@event, context => Task.FromResult(condition(context)), activities)
+
+
+        public ConditionalActivityBinder(Event @event, StateMachineCondition<TInstance> condition,
+            EventActivities<TInstance> thenActivities, EventActivities<TInstance> elseActivities)
+            : this(@event, context => Task.FromResult(condition(context)), thenActivities, elseActivities)
         {
         }
 
-        public ConditionalActivityBinder(Event @event, StateMachineAsyncCondition<TInstance> condition, EventActivities<TInstance> activities)
+        public ConditionalActivityBinder(Event @event, StateMachineAsyncCondition<TInstance> condition,
+            EventActivities<TInstance> thenActivities, EventActivities<TInstance> elseActivities)
         {
-            _activities = activities;
+            _thenActivities = thenActivities;
+            _elseActivities = elseActivities;
             _condition = condition;
             _event = @event;
         }
@@ -45,30 +51,34 @@ namespace Automatonymous.Binders
 
         public void Bind(State<TInstance> state)
         {
-            var builder = new ActivityBehaviorBuilder<TInstance>();
+            var thenBehavior = GetBehavior(_thenActivities);
+            var elseBehavior = GetBehavior(_elseActivities);
 
-            foreach (var activity in _activities.GetStateActivityBinders())
-            {
-                activity.Bind(builder);
-            }
-
-            var conditionActivity = new ConditionActivity<TInstance>(_condition, builder.Behavior);
+            var conditionActivity = new ConditionActivity<TInstance>(_condition, thenBehavior, elseBehavior);
 
             state.Bind(_event, conditionActivity);
         }
 
         public void Bind(BehaviorBuilder<TInstance> builder)
         {
-            var stateBuilder = new ActivityBehaviorBuilder<TInstance>();
+            var thenBehavior = GetBehavior(_thenActivities);
+            var elseBehavior = GetBehavior(_elseActivities);
 
-            foreach (var activity in _activities.GetStateActivityBinders())
-            {
-                activity.Bind(stateBuilder);
-            }
-
-            var conditionActivity = new ConditionActivity<TInstance>(_condition, stateBuilder.Behavior);
+            var conditionActivity = new ConditionActivity<TInstance>(_condition, thenBehavior, elseBehavior);
 
             builder.Add(conditionActivity);
+        }
+
+        private static Behavior<TInstance> GetBehavior(EventActivities<TInstance> activities)
+        {
+            var builder = new ActivityBehaviorBuilder<TInstance>();
+
+            foreach (var activity in activities.GetStateActivityBinders())
+            {
+                activity.Bind(builder);
+            }
+
+            return builder.Behavior;
         }
     }
 
@@ -77,20 +87,22 @@ namespace Automatonymous.Binders
         ActivityBinder<TInstance>
         where TInstance : class
     {
-        readonly EventActivities<TInstance> _activities;
+        readonly EventActivities<TInstance> _thenActivities;
+        readonly EventActivities<TInstance> _elseActivities;
         readonly StateMachineAsyncCondition<TInstance, TData> _condition;
         readonly Event _event;
 
         public ConditionalActivityBinder(Event @event, StateMachineCondition<TInstance, TData> condition,
-            EventActivities<TInstance> activities)
-            : this(@event, context => Task.FromResult(condition(context)), activities)
+            EventActivities<TInstance> thenActivities, EventActivities<TInstance> elseActivities)
+            : this(@event, context => Task.FromResult(condition(context)), thenActivities, elseActivities)
         {
         }
 
         public ConditionalActivityBinder(Event @event, StateMachineAsyncCondition<TInstance, TData> condition,
-            EventActivities<TInstance> activities)
+            EventActivities<TInstance> thenActivities, EventActivities<TInstance> elseActivities)
         {
-            _activities = activities;
+            _thenActivities = thenActivities;
+            _elseActivities = elseActivities;
             _condition = condition;
             _event = @event;
         }
@@ -103,30 +115,34 @@ namespace Automatonymous.Binders
 
         public void Bind(State<TInstance> state)
         {
-            var builder = new ActivityBehaviorBuilder<TInstance>();
+            var thenBehavior = GetBehavior(_thenActivities);
+            var elseBehavior = GetBehavior(_elseActivities);
 
-            foreach (var activity in _activities.GetStateActivityBinders())
-            {
-                activity.Bind(builder);
-            }
-
-            var conditionActivity = new ConditionActivity<TInstance, TData>(_condition, builder.Behavior);
+            var conditionActivity = new ConditionActivity<TInstance, TData>(_condition, thenBehavior, elseBehavior);
 
             state.Bind(_event, conditionActivity);
         }
 
         public void Bind(BehaviorBuilder<TInstance> builder)
         {
-            var stateBuilder = new ActivityBehaviorBuilder<TInstance>();
+            var thenBehavior = GetBehavior(_thenActivities);
+            var elseBehavior = GetBehavior(_elseActivities);
 
-            foreach (var activity in _activities.GetStateActivityBinders())
-            {
-                activity.Bind(stateBuilder);
-            }
-
-            var conditionActivity = new ConditionActivity<TInstance, TData>(_condition, stateBuilder.Behavior);
+            var conditionActivity = new ConditionActivity<TInstance, TData>(_condition, thenBehavior, elseBehavior);
 
             builder.Add(conditionActivity);
+        }
+
+        private static Behavior<TInstance> GetBehavior(EventActivities<TInstance> activities)
+        {
+            var builder = new ActivityBehaviorBuilder<TInstance>();
+
+            foreach (var activity in activities.GetStateActivityBinders())
+            {
+                activity.Bind(builder);
+            }
+
+            return builder.Behavior;
         }
     }
 }

--- a/src/Automatonymous/Binders/ConditionalExceptionActivityBinder.cs
+++ b/src/Automatonymous/Binders/ConditionalExceptionActivityBinder.cs
@@ -1,0 +1,123 @@
+// Copyright 2011-2016 Chris Patterson, Dru Sellers
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Automatonymous.Binders
+{
+    using System;
+    using Activities;
+    using Behaviors;
+
+
+    public class ConditionalExceptionActivityBinder<TInstance, TException> :
+        ActivityBinder<TInstance>
+        where TInstance : class
+        where TException : Exception
+    {
+        readonly EventActivities<TInstance> _activities;
+        readonly StateMachineCondition<TInstance> _condition;
+        readonly Event _event;
+
+        public ConditionalExceptionActivityBinder(Event @event, StateMachineCondition<TInstance> condition, EventActivities<TInstance> activities)
+        {
+            _activities = activities;
+            _condition = condition;
+            _event = @event;
+        }
+
+        public bool IsStateTransitionEvent(State state)
+        {
+            return Equals(_event, state.Enter) || Equals(_event, state.BeforeEnter)
+                   || Equals(_event, state.AfterLeave) || Equals(_event, state.Leave);
+        }
+
+        public void Bind(State<TInstance> state)
+        {
+            var catchBuilder = new CatchBehaviorBuilder<TInstance>();
+
+            foreach (var activity in _activities.GetStateActivityBinders())
+            {
+                activity.Bind(catchBuilder);
+            }
+
+            var conditionActivity = new ConditionExceptionActivity<TInstance, TException>(_condition, catchBuilder.Behavior);
+
+            state.Bind(_event, conditionActivity);
+        }
+
+        public void Bind(BehaviorBuilder<TInstance> builder)
+        {
+            var catchBuilder = new CatchBehaviorBuilder<TInstance>();
+
+            foreach (var activity in _activities.GetStateActivityBinders())
+            {
+                activity.Bind(catchBuilder);
+            }
+
+            var conditionActivity = new ConditionExceptionActivity<TInstance, TException>(_condition, catchBuilder.Behavior);
+
+            builder.Add(conditionActivity);
+        }
+    }
+
+
+    public class ConditionalExceptionActivityBinder<TInstance, TData, TException> :
+        ActivityBinder<TInstance>
+        where TInstance : class
+        where TException : Exception
+    {
+        readonly EventActivities<TInstance> _activities;
+        readonly StateMachineCondition<TInstance, TData> _condition;
+        readonly Event _event;
+
+        public ConditionalExceptionActivityBinder(Event @event, StateMachineCondition<TInstance, TData> condition,
+            EventActivities<TInstance> activities)
+        {
+            _activities = activities;
+            _condition = condition;
+            _event = @event;
+        }
+
+        public bool IsStateTransitionEvent(State state)
+        {
+            return Equals(_event, state.Enter) || Equals(_event, state.BeforeEnter)
+                   || Equals(_event, state.AfterLeave) || Equals(_event, state.Leave);
+        }
+
+        public void Bind(State<TInstance> state)
+        {
+            var catchBuilder = new CatchBehaviorBuilder<TInstance>();
+
+            foreach (var activity in _activities.GetStateActivityBinders())
+            {
+                activity.Bind(catchBuilder);
+            }
+
+            var conditionActivity = new ConditionExceptionActivity<TInstance, TData, TException>(_condition, catchBuilder.Behavior);
+
+            state.Bind(_event, conditionActivity);
+        }
+
+        public void Bind(BehaviorBuilder<TInstance> builder)
+        {
+            var catchBuilder = new CatchBehaviorBuilder<TInstance>();
+
+            foreach (var activity in _activities.GetStateActivityBinders())
+            {
+                activity.Bind(catchBuilder);
+            }
+
+            var conditionActivity = new ConditionExceptionActivity<TInstance, TData, TException>(_condition, catchBuilder.Behavior);
+
+            builder.Add(conditionActivity);
+        }
+    }
+}

--- a/src/Automatonymous/Binders/ConditionalExceptionActivityBinder.cs
+++ b/src/Automatonymous/Binders/ConditionalExceptionActivityBinder.cs
@@ -13,6 +13,7 @@
 namespace Automatonymous.Binders
 {
     using System;
+    using System.Threading.Tasks;
     using Activities;
     using Behaviors;
 
@@ -23,10 +24,15 @@ namespace Automatonymous.Binders
         where TException : Exception
     {
         readonly EventActivities<TInstance> _activities;
-        readonly StateMachineExceptionCondition<TInstance, TException> _condition;
+        readonly StateMachineAsyncExceptionCondition<TInstance, TException> _condition;
         readonly Event _event;
 
         public ConditionalExceptionActivityBinder(Event @event, StateMachineExceptionCondition<TInstance, TException> condition, EventActivities<TInstance> activities)
+            :this(@event, context => Task.FromResult(condition(context)), activities)
+        {
+        }
+
+        public ConditionalExceptionActivityBinder(Event @event, StateMachineAsyncExceptionCondition<TInstance, TException> condition, EventActivities<TInstance> activities)
         {
             _activities = activities;
             _condition = condition;
@@ -75,10 +81,15 @@ namespace Automatonymous.Binders
         where TException : Exception
     {
         readonly EventActivities<TInstance> _activities;
-        readonly StateMachineExceptionCondition<TInstance, TData, TException> _condition;
+        readonly StateMachineAsyncExceptionCondition<TInstance, TData, TException> _condition;
         readonly Event _event;
 
-        public ConditionalExceptionActivityBinder(Event @event, StateMachineExceptionCondition<TInstance, TData, TException> condition,
+        public ConditionalExceptionActivityBinder(Event @event, StateMachineExceptionCondition<TInstance, TData, TException> condition, EventActivities<TInstance> activities)
+            : this(@event, context => Task.FromResult(condition(context)), activities)
+        {
+        }
+
+        public ConditionalExceptionActivityBinder(Event @event, StateMachineAsyncExceptionCondition<TInstance, TData, TException> condition,
             EventActivities<TInstance> activities)
         {
             _activities = activities;

--- a/src/Automatonymous/Binders/ConditionalExceptionActivityBinder.cs
+++ b/src/Automatonymous/Binders/ConditionalExceptionActivityBinder.cs
@@ -23,18 +23,22 @@ namespace Automatonymous.Binders
         where TInstance : class
         where TException : Exception
     {
-        readonly EventActivities<TInstance> _activities;
+        readonly EventActivities<TInstance> _thenActivities;
+        readonly EventActivities<TInstance> _elseActivities;
         readonly StateMachineAsyncExceptionCondition<TInstance, TException> _condition;
         readonly Event _event;
 
-        public ConditionalExceptionActivityBinder(Event @event, StateMachineExceptionCondition<TInstance, TException> condition, EventActivities<TInstance> activities)
-            :this(@event, context => Task.FromResult(condition(context)), activities)
+        public ConditionalExceptionActivityBinder(Event @event, StateMachineExceptionCondition<TInstance, TException> condition,
+            EventActivities<TInstance> thenActivities, EventActivities<TInstance> elseActivities)
+            :this(@event, context => Task.FromResult(condition(context)), thenActivities, elseActivities)
         {
         }
 
-        public ConditionalExceptionActivityBinder(Event @event, StateMachineAsyncExceptionCondition<TInstance, TException> condition, EventActivities<TInstance> activities)
+        public ConditionalExceptionActivityBinder(Event @event, StateMachineAsyncExceptionCondition<TInstance, TException> condition,
+            EventActivities<TInstance> thenActivities, EventActivities<TInstance> elseActivities)
         {
-            _activities = activities;
+            _thenActivities = thenActivities;
+            _elseActivities = elseActivities;
             _condition = condition;
             _event = @event;
         }
@@ -47,30 +51,33 @@ namespace Automatonymous.Binders
 
         public void Bind(State<TInstance> state)
         {
-            var catchBuilder = new CatchBehaviorBuilder<TInstance>();
+            var thenBehavior = GetBehavior(_thenActivities);
+            var elseBehavior = GetBehavior(_elseActivities);
 
-            foreach (var activity in _activities.GetStateActivityBinders())
-            {
-                activity.Bind(catchBuilder);
-            }
-
-            var conditionActivity = new ConditionExceptionActivity<TInstance, TException>(_condition, catchBuilder.Behavior);
+            var conditionActivity = new ConditionExceptionActivity<TInstance, TException>(_condition, thenBehavior, elseBehavior);
 
             state.Bind(_event, conditionActivity);
         }
 
         public void Bind(BehaviorBuilder<TInstance> builder)
         {
+            var thenBehavior = GetBehavior(_thenActivities);
+            var elseBehavior = GetBehavior(_elseActivities);
+
+            var conditionActivity = new ConditionExceptionActivity<TInstance, TException>(_condition, thenBehavior, elseBehavior);
+
+            builder.Add(conditionActivity);
+        }
+
+        private Behavior<TInstance> GetBehavior(EventActivities<TInstance> activities)
+        {
             var catchBuilder = new CatchBehaviorBuilder<TInstance>();
 
-            foreach (var activity in _activities.GetStateActivityBinders())
+            foreach (var activity in activities.GetStateActivityBinders())
             {
                 activity.Bind(catchBuilder);
             }
-
-            var conditionActivity = new ConditionExceptionActivity<TInstance, TException>(_condition, catchBuilder.Behavior);
-
-            builder.Add(conditionActivity);
+            return catchBuilder.Behavior;
         }
     }
 
@@ -80,19 +87,22 @@ namespace Automatonymous.Binders
         where TInstance : class
         where TException : Exception
     {
-        readonly EventActivities<TInstance> _activities;
+        readonly EventActivities<TInstance> _thenActivities;
+        readonly EventActivities<TInstance> _elseActivities;
         readonly StateMachineAsyncExceptionCondition<TInstance, TData, TException> _condition;
         readonly Event _event;
 
-        public ConditionalExceptionActivityBinder(Event @event, StateMachineExceptionCondition<TInstance, TData, TException> condition, EventActivities<TInstance> activities)
-            : this(@event, context => Task.FromResult(condition(context)), activities)
+        public ConditionalExceptionActivityBinder(Event @event, StateMachineExceptionCondition<TInstance, TData, TException> condition,
+            EventActivities<TInstance> thenActivities, EventActivities<TInstance> elseActivities)
+            : this(@event, context => Task.FromResult(condition(context)), thenActivities, elseActivities)
         {
         }
 
         public ConditionalExceptionActivityBinder(Event @event, StateMachineAsyncExceptionCondition<TInstance, TData, TException> condition,
-            EventActivities<TInstance> activities)
+            EventActivities<TInstance> thenActivities, EventActivities<TInstance> elseActivities)
         {
-            _activities = activities;
+            _thenActivities = thenActivities;
+            _elseActivities = elseActivities;
             _condition = condition;
             _event = @event;
         }
@@ -105,30 +115,34 @@ namespace Automatonymous.Binders
 
         public void Bind(State<TInstance> state)
         {
-            var catchBuilder = new CatchBehaviorBuilder<TInstance>();
+            var thenBehavior = GetBehavior(_thenActivities);
+            var elseBehavior = GetBehavior(_elseActivities);
 
-            foreach (var activity in _activities.GetStateActivityBinders())
-            {
-                activity.Bind(catchBuilder);
-            }
-
-            var conditionActivity = new ConditionExceptionActivity<TInstance, TData, TException>(_condition, catchBuilder.Behavior);
+            var conditionActivity = new ConditionExceptionActivity<TInstance, TData, TException>(_condition, thenBehavior, elseBehavior);
 
             state.Bind(_event, conditionActivity);
         }
 
         public void Bind(BehaviorBuilder<TInstance> builder)
         {
+            var thenBehavior = GetBehavior(_thenActivities);
+            var elseBehavior = GetBehavior(_elseActivities);
+
+            var conditionActivity = new ConditionExceptionActivity<TInstance, TData, TException>(_condition, thenBehavior, elseBehavior);
+
+            builder.Add(conditionActivity);
+        }
+
+        private Behavior<TInstance> GetBehavior(EventActivities<TInstance> activities)
+        {
             var catchBuilder = new CatchBehaviorBuilder<TInstance>();
 
-            foreach (var activity in _activities.GetStateActivityBinders())
+            foreach (var activity in activities.GetStateActivityBinders())
             {
                 activity.Bind(catchBuilder);
             }
 
-            var conditionActivity = new ConditionExceptionActivity<TInstance, TData, TException>(_condition, catchBuilder.Behavior);
-
-            builder.Add(conditionActivity);
+            return catchBuilder.Behavior;
         }
     }
 }

--- a/src/Automatonymous/Binders/ConditionalExceptionActivityBinder.cs
+++ b/src/Automatonymous/Binders/ConditionalExceptionActivityBinder.cs
@@ -23,10 +23,10 @@ namespace Automatonymous.Binders
         where TException : Exception
     {
         readonly EventActivities<TInstance> _activities;
-        readonly StateMachineCondition<TInstance> _condition;
+        readonly StateMachineExceptionCondition<TInstance, TException> _condition;
         readonly Event _event;
 
-        public ConditionalExceptionActivityBinder(Event @event, StateMachineCondition<TInstance> condition, EventActivities<TInstance> activities)
+        public ConditionalExceptionActivityBinder(Event @event, StateMachineExceptionCondition<TInstance, TException> condition, EventActivities<TInstance> activities)
         {
             _activities = activities;
             _condition = condition;
@@ -75,10 +75,10 @@ namespace Automatonymous.Binders
         where TException : Exception
     {
         readonly EventActivities<TInstance> _activities;
-        readonly StateMachineCondition<TInstance, TData> _condition;
+        readonly StateMachineExceptionCondition<TInstance, TData, TException> _condition;
         readonly Event _event;
 
-        public ConditionalExceptionActivityBinder(Event @event, StateMachineCondition<TInstance, TData> condition,
+        public ConditionalExceptionActivityBinder(Event @event, StateMachineExceptionCondition<TInstance, TData, TException> condition,
             EventActivities<TInstance> activities)
         {
             _activities = activities;

--- a/src/Automatonymous/Binders/DataEventActivityBinder.cs
+++ b/src/Automatonymous/Binders/DataEventActivityBinder.cs
@@ -94,6 +94,18 @@ namespace Automatonymous.Binders
             return new DataEventActivityBinder<TInstance, TData>(_machine, _event, _filter, _activities, conditionBinder);
         }
 
+        EventActivityBinder<TInstance, TData> EventActivityBinder<TInstance, TData>.IfAsync(StateMachineAsyncCondition<TInstance, TData> condition,
+            Func<EventActivityBinder<TInstance, TData>, EventActivityBinder<TInstance, TData>> activityCallback)
+        {
+            EventActivityBinder<TInstance, TData> binder = new DataEventActivityBinder<TInstance, TData>(_machine, _event);
+
+            binder = activityCallback(binder);
+
+            var conditionBinder = new ConditionalActivityBinder<TInstance, TData>(_event, condition, binder);
+
+            return new DataEventActivityBinder<TInstance, TData>(_machine, _event, _filter, _activities, conditionBinder);
+        }
+
         StateMachine<TInstance> EventActivityBinder<TInstance, TData>.StateMachine => _machine;
 
         public IEnumerable<ActivityBinder<TInstance>> GetStateActivityBinders()

--- a/src/Automatonymous/Binders/EventActivityBinder.cs
+++ b/src/Automatonymous/Binders/EventActivityBinder.cs
@@ -52,6 +52,28 @@ namespace Automatonymous.Binders
         /// <returns></returns>
         EventActivityBinder<TInstance> IfAsync(StateMachineAsyncCondition<TInstance> condition,
             Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> activityCallback);
+
+        /// <summary>
+        /// Create a conditional branch of activities for processing
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="thenActivityCallback"></param>
+        /// <param name="elseActivityCallback"></param>
+        /// <returns></returns>
+        EventActivityBinder<TInstance> IfElse(StateMachineCondition<TInstance> condition,
+            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> thenActivityCallback,
+            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> elseActivityCallback);
+
+        /// <summary>
+        /// Create a conditional branch of activities for processing
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="thenActivityCallback"></param>
+        /// <param name="elseActivityCallback"></param>
+        /// <returns></returns>
+        EventActivityBinder<TInstance> IfElseAsync(StateMachineAsyncCondition<TInstance> condition,
+            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> thenActivityCallback,
+            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> elseActivityCallback);
     }
 
 
@@ -94,5 +116,27 @@ namespace Automatonymous.Binders
         /// <returns></returns>
         EventActivityBinder<TInstance, TData> IfAsync(StateMachineAsyncCondition<TInstance, TData> condition,
             Func<EventActivityBinder<TInstance, TData>, EventActivityBinder<TInstance, TData>> activityCallback);
+
+        /// <summary>
+        /// Create a conditional branch of activities for processing
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="thenActivityCallback"></param>
+        /// <param name="elseActivityCallback"></param>
+        /// <returns></returns>
+        EventActivityBinder<TInstance, TData> IfElse(StateMachineCondition<TInstance, TData> condition,
+            Func<EventActivityBinder<TInstance, TData>, EventActivityBinder<TInstance, TData>> thenActivityCallback,
+            Func<EventActivityBinder<TInstance, TData>, EventActivityBinder<TInstance, TData>> elseActivityCallback);
+
+        /// <summary>
+        /// Create a conditional branch of activities for processing
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="thenActivityCallback"></param>
+        /// <param name="elseActivityCallback"></param>
+        /// <returns></returns>
+        EventActivityBinder<TInstance, TData> IfElseAsync(StateMachineAsyncCondition<TInstance, TData> condition,
+            Func<EventActivityBinder<TInstance, TData>, EventActivityBinder<TInstance, TData>> thenActivityCallback,
+            Func<EventActivityBinder<TInstance, TData>, EventActivityBinder<TInstance, TData>> elseActivityCallback);
     }
 }

--- a/src/Automatonymous/Binders/EventActivityBinder.cs
+++ b/src/Automatonymous/Binders/EventActivityBinder.cs
@@ -43,6 +43,15 @@ namespace Automatonymous.Binders
         /// <returns></returns>
         EventActivityBinder<TInstance> If(StateMachineCondition<TInstance> condition,
             Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> activityCallback);
+
+        /// <summary>
+        /// Create a conditional branch of activities for processing
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="activityCallback"></param>
+        /// <returns></returns>
+        EventActivityBinder<TInstance> IfAsync(StateMachineAsyncCondition<TInstance> condition,
+            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> activityCallback);
     }
 
 
@@ -75,6 +84,15 @@ namespace Automatonymous.Binders
         /// <param name="activityCallback"></param>
         /// <returns></returns>
         EventActivityBinder<TInstance, TData> If(StateMachineCondition<TInstance, TData> condition,
+            Func<EventActivityBinder<TInstance, TData>, EventActivityBinder<TInstance, TData>> activityCallback);
+
+        /// <summary>
+        /// Create a conditional branch of activities for processing
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="activityCallback"></param>
+        /// <returns></returns>
+        EventActivityBinder<TInstance, TData> IfAsync(StateMachineAsyncCondition<TInstance, TData> condition,
             Func<EventActivityBinder<TInstance, TData>, EventActivityBinder<TInstance, TData>> activityCallback);
     }
 }

--- a/src/Automatonymous/Binders/ExceptionActivityBinder.cs
+++ b/src/Automatonymous/Binders/ExceptionActivityBinder.cs
@@ -53,6 +53,28 @@ namespace Automatonymous.Binders
         /// <returns></returns>
         ExceptionActivityBinder<TInstance, TException> IfAsync(StateMachineAsyncExceptionCondition<TInstance, TException> condition,
             Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> activityCallback);
+
+        /// <summary>
+        /// Create a conditional branch of activities for processing
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="thenActivityCallback"></param>
+        /// <param name="elseActivityCallback"></param>
+        /// <returns></returns>
+        ExceptionActivityBinder<TInstance, TException> IfElse(StateMachineExceptionCondition<TInstance, TException> condition,
+            Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> thenActivityCallback,
+            Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> elseActivityCallback);
+
+        /// <summary>
+        /// Create a conditional branch of activities for processing
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="thenActivityCallback"></param>
+        /// <param name="elseActivityCallback"></param>
+        /// <returns></returns>
+        ExceptionActivityBinder<TInstance, TException> IfElseAsync(StateMachineAsyncExceptionCondition<TInstance, TException> condition,
+            Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> thenActivityCallback,
+            Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> elseActivityCallback);
     }
 
 
@@ -96,5 +118,27 @@ namespace Automatonymous.Binders
         /// <returns></returns>
         ExceptionActivityBinder<TInstance, TData, TException> IfAsync(StateMachineAsyncExceptionCondition<TInstance, TData, TException> condition,
             Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> activityCallback);
+
+        /// <summary>
+        /// Create a conditional branch of activities for processing
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="thenActivityCallback"></param>
+        /// <param name="elseActivityCallback"></param>
+        /// <returns></returns>
+        ExceptionActivityBinder<TInstance, TData, TException> IfElse(StateMachineExceptionCondition<TInstance, TData, TException> condition,
+            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> thenActivityCallback,
+            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> elseActivityCallback);
+
+        /// <summary>
+        /// Create a conditional branch of activities for processing
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="thenActivityCallback"></param>
+        /// <param name="elseActivityCallback"></param>
+        /// <returns></returns>
+        ExceptionActivityBinder<TInstance, TData, TException> IfElseAsync(StateMachineAsyncExceptionCondition<TInstance, TData, TException> condition,
+            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> thenActivityCallback,
+            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> elseActivityCallback);
     }
 }

--- a/src/Automatonymous/Binders/ExceptionActivityBinder.cs
+++ b/src/Automatonymous/Binders/ExceptionActivityBinder.cs
@@ -42,7 +42,7 @@ namespace Automatonymous.Binders
         /// <param name="condition"></param>
         /// <param name="activityCallback"></param>
         /// <returns></returns>
-        ExceptionActivityBinder<TInstance, TException> If(StateMachineCondition<TInstance> condition,
+        ExceptionActivityBinder<TInstance, TException> If(StateMachineExceptionCondition<TInstance, TException> condition,
             Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> activityCallback);
     }
 
@@ -76,7 +76,7 @@ namespace Automatonymous.Binders
         /// <param name="condition"></param>
         /// <param name="activityCallback"></param>
         /// <returns></returns>
-        ExceptionActivityBinder<TInstance, TData, TException> If(StateMachineCondition<TInstance, TData> condition,
+        ExceptionActivityBinder<TInstance, TData, TException> If(StateMachineExceptionCondition<TInstance, TData, TException> condition,
             Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>>
                 activityCallback);
     }

--- a/src/Automatonymous/Binders/ExceptionActivityBinder.cs
+++ b/src/Automatonymous/Binders/ExceptionActivityBinder.cs
@@ -44,6 +44,15 @@ namespace Automatonymous.Binders
         /// <returns></returns>
         ExceptionActivityBinder<TInstance, TException> If(StateMachineExceptionCondition<TInstance, TException> condition,
             Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> activityCallback);
+
+        /// <summary>
+        /// Create a conditional branch of activities for processing
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="activityCallback"></param>
+        /// <returns></returns>
+        ExceptionActivityBinder<TInstance, TException> IfAsync(StateMachineAsyncExceptionCondition<TInstance, TException> condition,
+            Func<ExceptionActivityBinder<TInstance, TException>, ExceptionActivityBinder<TInstance, TException>> activityCallback);
     }
 
 
@@ -77,7 +86,15 @@ namespace Automatonymous.Binders
         /// <param name="activityCallback"></param>
         /// <returns></returns>
         ExceptionActivityBinder<TInstance, TData, TException> If(StateMachineExceptionCondition<TInstance, TData, TException> condition,
-            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>>
-                activityCallback);
+            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> activityCallback);
+
+        /// <summary>
+        /// Create a conditional branch of activities for processing
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="activityCallback"></param>
+        /// <returns></returns>
+        ExceptionActivityBinder<TInstance, TData, TException> IfAsync(StateMachineAsyncExceptionCondition<TInstance, TData, TException> condition,
+            Func<ExceptionActivityBinder<TInstance, TData, TException>, ExceptionActivityBinder<TInstance, TData, TException>> activityCallback);
     }
 }

--- a/src/Automatonymous/Binders/TriggerEventActivityBinder.cs
+++ b/src/Automatonymous/Binders/TriggerEventActivityBinder.cs
@@ -88,6 +88,18 @@ namespace Automatonymous.Binders
             return new TriggerEventActivityBinder<TInstance>(_machine, _event, _filter, _activities, conditionBinder);
         }
 
+        EventActivityBinder<TInstance> EventActivityBinder<TInstance>.IfAsync(StateMachineAsyncCondition<TInstance> condition,
+            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> activityCallback)
+        {
+            EventActivityBinder<TInstance> binder = new TriggerEventActivityBinder<TInstance>(_machine, _event);
+
+            binder = activityCallback(binder);
+
+            var conditionBinder = new ConditionalActivityBinder<TInstance>(_event, condition, binder);
+
+            return new TriggerEventActivityBinder<TInstance>(_machine, _event, _filter, _activities, conditionBinder);
+        }
+
         StateMachine<TInstance> EventActivityBinder<TInstance>.StateMachine => _machine;
 
         public IEnumerable<ActivityBinder<TInstance>> GetStateActivityBinders()

--- a/src/Automatonymous/StateMachineAsyncCondition.cs
+++ b/src/Automatonymous/StateMachineAsyncCondition.cs
@@ -1,0 +1,34 @@
+// Copyright 2011-2019 Chris Patterson, Dru Sellers
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Automatonymous
+{
+    using System.Threading.Tasks;
+
+
+    /// <summary>
+    /// Filters activities based on the async conditional statement
+    /// </summary>
+    /// <typeparam name="TInstance"></typeparam>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    public delegate Task<bool> StateMachineAsyncCondition<in TInstance, in TData>(BehaviorContext<TInstance, TData> context);
+
+
+    /// <summary>
+    /// Filters activities based on the async conditional statement
+    /// </summary>
+    /// <typeparam name="TInstance"></typeparam>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    public delegate Task<bool> StateMachineAsyncCondition<in TInstance>(BehaviorContext<TInstance> context);
+}

--- a/src/Automatonymous/StateMachineAsyncExceptionCondition.cs
+++ b/src/Automatonymous/StateMachineAsyncExceptionCondition.cs
@@ -1,0 +1,50 @@
+// Copyright 2011-2019 Chris Patterson, Dru Sellers
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+// Copyright 2011-2019 Chris Patterson, Dru Sellers
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Automatonymous
+{
+    using System;
+    using System.Threading.Tasks;
+
+
+    /// <summary>
+    /// Filters activities based on the conditional statement
+    /// </summary>
+    /// <typeparam name="TInstance"></typeparam>
+    /// <typeparam name="TData"></typeparam>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    public delegate Task<bool> StateMachineAsyncExceptionCondition<in TInstance, in TData, in TException>(BehaviorExceptionContext<TInstance, TData, TException> context)
+        where TException : Exception;
+
+
+    /// <summary>
+    /// Filters activities based on the conditional statement
+    /// </summary>
+    /// <typeparam name="TInstance"></typeparam>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    public delegate Task<bool> StateMachineAsyncExceptionCondition<in TInstance, in TException>(BehaviorExceptionContext<TInstance, TException> context)
+        where TException : Exception;
+}

--- a/src/Automatonymous/StateMachineExceptionCondition.cs
+++ b/src/Automatonymous/StateMachineExceptionCondition.cs
@@ -1,0 +1,49 @@
+// Copyright 2011-2019 Chris Patterson, Dru Sellers
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+// Copyright 2011-2019 Chris Patterson, Dru Sellers
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use 
+// this file except in compliance with the License. You may obtain a copy of the 
+// License at 
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+namespace Automatonymous
+{
+    using System;
+
+
+    /// <summary>
+    /// Filters activities based on the conditional statement
+    /// </summary>
+    /// <typeparam name="TInstance"></typeparam>
+    /// <typeparam name="TData"></typeparam>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    public delegate bool StateMachineExceptionCondition<in TInstance, in TData, in TException>(BehaviorExceptionContext<TInstance, TData, TException> context)
+        where TException : Exception;
+
+
+    /// <summary>
+    /// Filters activities based on the conditional statement
+    /// </summary>
+    /// <typeparam name="TInstance"></typeparam>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    public delegate bool StateMachineExceptionCondition<in TInstance, in TException>(BehaviorExceptionContext<TInstance, TException> context)
+        where TException : Exception;
+}


### PR DESCRIPTION
This PR consists in 3 main parts, one being a bug correction, and two being enhancements.

### Exception If bug correction
The If statement being part of the Exception path was broken.
The 3 first commits aim to solve this situation.

### Async conditions support for If
IfAsync has been added to support async conditions. This is great when the condition relies on an async operations, like http calls, or IO in general.

### Else support for If
If and IfAsync have been extended by adding IfElse/IfElseAsync to support an else construct.
This is especially interesting when the condition might have side effects or be costly (like http calls), as it allows to execute it only once, without relying on storing the result of the condition in the instance.
I think it solves #52.

-----
I know this PR mixes concerns a little bit, but as these enhancements are related to the same area, it would have been time-consuming to sequence them.

Would be happy to get your review on this proposal and work to have this integrated into Automatonymous.