### PR TITLE
Migrate code base to QuikGraph.

### DIFF
--- a/src/Automatonymous.Tests/Visualizer_Specs.cs
+++ b/src/Automatonymous.Tests/Visualizer_Specs.cs
@@ -52,20 +52,19 @@
 8 [shape=rectangle, label=""Suspend""];
 9 [shape=rectangle, label=""Resume""];
 10 [shape=rectangle, label=""Restart<RestartData>""];
-0 -> 5 [ ];
-1 -> 7 [ ];
-1 -> 8 [ ];
-2 -> 10 [ ];
-4 -> 9 [ ];
-5 -> 1 [ ];
-5 -> 6 [ ];
-6 -> 2 [ ];
-7 -> 3 [ ];
-8 -> 4 [ ];
-9 -> 1 [ ];
-10 -> 1 [ ];
-}
-";
+0 -> 5;
+1 -> 7;
+1 -> 8;
+2 -> 10;
+4 -> 9;
+5 -> 1;
+5 -> 6;
+6 -> 2;
+7 -> 3;
+8 -> 4;
+9 -> 1;
+10 -> 1;
+}";
 
 
         class Instance

--- a/src/Automatonymous.Visualizer/Automatonymous.Visualizer.csproj
+++ b/src/Automatonymous.Visualizer/Automatonymous.Visualizer.csproj
@@ -11,7 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="QuickGraph.NETStandard" Version="3.8.0"/>
+    <PackageReference Include="QuikGraph" Version="2.2.0"/>
+    <PackageReference Include="QuikGraph.Graphviz" Version="2.2.0"/>
     <ProjectReference Include="..\Automatonymous\Automatonymous.csproj"/>
   </ItemGroup>
 

--- a/src/Automatonymous.Visualizer/StateMachineGraphGenerator.cs
+++ b/src/Automatonymous.Visualizer/StateMachineGraphGenerator.cs
@@ -3,10 +3,9 @@
     using System;
     using System.Linq;
     using Graphing;
-    using QuickGraph;
-    using QuickGraph.Graphviz;
-    using QuickGraph.Graphviz.Dot;
-
+    using QuikGraph;
+    using QuikGraph.Graphviz;
+    using QuikGraph.Graphviz.Dot;
 
     public class StateMachineGraphvizGenerator
     {
@@ -20,48 +19,43 @@
         public string CreateDotFile()
         {
             var algorithm = new GraphvizAlgorithm<Vertex, Edge<Vertex>>(_graph);
-            algorithm.FormatEdge += EdgeStyler;
             algorithm.FormatVertex += VertexStyler;
             return algorithm.Generate();
         }
 
-        void EdgeStyler(object sender, FormatEdgeEventArgs<Vertex, Edge<Vertex>> e)
+        private static void VertexStyler(object sender, FormatVertexEventArgs<Vertex> args)
         {
-        }
+            args.VertexFormat.Label = args.Vertex.Title;
 
-        void VertexStyler(object sender, FormatVertexEventArgs<Vertex> e)
-        {
-            e.VertexFormatter.Label = e.Vertex.Title;
-
-            if (e.Vertex.VertexType == typeof(Event))
+            if (args.Vertex.VertexType == typeof(Event))
             {
-                e.VertexFormatter.FontColor = GraphvizColor.Black;
-                e.VertexFormatter.Shape = GraphvizVertexShape.Rectangle;
+                args.VertexFormat.FontColor = GraphvizColor.Black;
+                args.VertexFormat.Shape = GraphvizVertexShape.Rectangle;
 
-                if (e.Vertex.TargetType != typeof(Event) && e.Vertex.TargetType != typeof(Exception))
-                    e.VertexFormatter.Label += "<" + e.Vertex.TargetType.Name + ">";
+                if (args.Vertex.TargetType != typeof(Event) && args.Vertex.TargetType != typeof(Exception))
+                    args.VertexFormat.Label += "<" + args.Vertex.TargetType.Name + ">";
             }
             else
             {
-                switch (e.Vertex.Title)
+                switch (args.Vertex.Title)
                 {
                     case "Initial":
-                        e.VertexFormatter.FillColor = GraphvizColor.White;
+                        args.VertexFormat.FillColor = GraphvizColor.White;
                         break;
                     case "Final":
-                        e.VertexFormatter.FillColor = GraphvizColor.White;
+                        args.VertexFormat.FillColor = GraphvizColor.White;
                         break;
                     default:
-                        e.VertexFormatter.FillColor = GraphvizColor.White;
-                        e.VertexFormatter.FontColor = GraphvizColor.Black;
+                        args.VertexFormat.FillColor = GraphvizColor.White;
+                        args.VertexFormat.FontColor = GraphvizColor.Black;
                         break;
                 }
 
-                e.VertexFormatter.Shape = GraphvizVertexShape.Ellipse;
+                args.VertexFormat.Shape = GraphvizVertexShape.Ellipse;
             }
         }
 
-        static AdjacencyGraph<Vertex, Edge<Vertex>> CreateAdjacencyGraph(StateMachineGraph data)
+        private static AdjacencyGraph<Vertex, Edge<Vertex>> CreateAdjacencyGraph(StateMachineGraph data)
         {
             var graph = new AdjacencyGraph<Vertex, Edge<Vertex>>();
 


### PR DESCRIPTION
Hello,

I updated the QuickGraph.NETStandard dependency to QuikGraph.

This library is using modern C# development workflow, have been ported to .NET Core too with a wider support in term of targets.
And finally it comes with a huge set of unit tests that has helped to debug and fix a lot of issues.
I also put some effort on the Graphviz module you are using to fix some issues and implement some missing stuff.

Here is the link to the library:
- [QuikGraph](https://github.com/KeRNeLith/QuikGraph)