### PR TITLE
Added ThenAsync faulted action activity

### DIFF
--- a/src/Automatonymous.Tests/Exception_Specs.cs
+++ b/src/Automatonymous.Tests/Exception_Specs.cs
@@ -29,6 +29,12 @@
         }
 
         [Test]
+        public void Should_have_called_the_async_then_block()
+        {
+            Assert.IsTrue(_instance.ThenAsyncShouldBeCalled);
+        }
+
+        [Test]
         public void Should_have_called_the_exception_handler()
         {
             Assert.AreEqual(_machine.Failed, _instance.CurrentState);
@@ -126,6 +132,8 @@
             public bool ElseShouldBeCalled { get; set; }
             public bool ThenAsyncShouldNotBeCalled { get; set; }
             public bool ElseAsyncShouldBeCalled { get; set; }
+
+            public bool ThenAsyncShouldBeCalled { get; set; }
         }
 
 
@@ -158,6 +166,11 @@
                             {
                                 context.Instance.ExceptionMessage = context.Exception.Message;
                                 context.Instance.ExceptionType = context.Exception.GetType();
+                            })
+                            .ThenAsync(context =>
+                            {
+                                context.Instance.ThenAsyncShouldBeCalled = true;
+                                return Task.CompletedTask;
                             })
                             .TransitionTo(Failed))
                         .Catch<Exception>(ex => ex

--- a/src/Automatonymous/Activities/AsyncFaultedActionActivity.cs
+++ b/src/Automatonymous/Activities/AsyncFaultedActionActivity.cs
@@ -1,0 +1,97 @@
+﻿namespace Automatonymous.Activities
+{
+    using System;
+    using System.Threading.Tasks;
+    using GreenPipes;
+
+
+    public class AsyncFaultedActionActivity<TInstance, TException> :
+        Activity<TInstance>
+        where TException : Exception
+    {
+        readonly Func<BehaviorExceptionContext<TInstance, TException>, Task> _asyncAction;
+
+        public AsyncFaultedActionActivity(Func<BehaviorExceptionContext<TInstance, TException>, Task> asyncAction)
+        {
+            _asyncAction = asyncAction;
+        }
+
+        void Visitable.Accept(StateMachineVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            context.CreateScope("then-async-faulted");
+        }
+
+        Task Activity<TInstance>.Execute(BehaviorContext<TInstance> context, Behavior<TInstance> next)
+        {
+            return next.Execute(context);
+        }
+
+        Task Activity<TInstance>.Execute<TData>(BehaviorContext<TInstance, TData> context, Behavior<TInstance, TData> next)
+        {
+            return next.Execute(context);
+        }
+
+        async Task Activity<TInstance>.Faulted<T>(BehaviorExceptionContext<TInstance, T> context, Behavior<TInstance> next)
+        {
+            var exceptionContext = context as BehaviorExceptionContext<TInstance, TException>;
+            if (exceptionContext != null)
+                await _asyncAction(exceptionContext);
+
+            await next.Faulted(context);
+        }
+
+        async Task Activity<TInstance>.Faulted<TData, T>(BehaviorExceptionContext<TInstance, TData, T> context,
+            Behavior<TInstance, TData> next)
+        {
+            var exceptionContext = context as BehaviorExceptionContext<TInstance, TData, TException>;
+            if (exceptionContext != null)
+                await _asyncAction(exceptionContext);
+
+            await next.Faulted(context);
+        }
+    }
+
+
+    public class AsyncFaultedActionActivity<TInstance, TData, TException> :
+        Activity<TInstance, TData>
+        where TInstance : class
+        where TException : Exception
+    {
+        readonly Func<BehaviorExceptionContext<TInstance, TData, TException>, Task> _asyncAction;
+
+        public AsyncFaultedActionActivity(Func<BehaviorExceptionContext<TInstance, TData, TException>, Task> asyncAction)
+        {
+            _asyncAction = asyncAction;
+        }
+
+        void Visitable.Accept(StateMachineVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        public void Probe(ProbeContext context)
+        {
+            context.CreateScope("then-async-faulted");
+        }
+
+        Task Activity<TInstance, TData>.Execute(BehaviorContext<TInstance, TData> context, Behavior<TInstance, TData> next)
+        {
+            return next.Execute(context);
+        }
+
+        async Task Activity<TInstance, TData>.Faulted<T>(BehaviorExceptionContext<TInstance, TData, T> context,
+            Behavior<TInstance, TData> next)
+        {
+            var exceptionContext = context as BehaviorExceptionContext<TInstance, TData, TException>;
+            if (exceptionContext != null)
+                await _asyncAction(exceptionContext);
+
+            await next.Faulted(context);
+        }
+    }
+}

--- a/src/Automatonymous/ThenExtensions.cs
+++ b/src/Automatonymous/ThenExtensions.cs
@@ -37,6 +37,21 @@ namespace Automatonymous
         }
 
         /// <summary>
+        /// Adds a asynchronous delegate activity to the event's behavior
+        /// </summary>
+        /// <typeparam name="TInstance">The state machine instance type</typeparam>
+        /// <typeparam name="TException">The exception type</typeparam>
+        /// <param name="binder">The event binder</param>
+        /// <param name="asyncAction">The asynchronous delegate</param>
+        public static ExceptionActivityBinder<TInstance, TException> ThenAsync<TInstance, TException>(
+            this ExceptionActivityBinder<TInstance, TException> binder, Func<BehaviorExceptionContext<TInstance, TException>, Task> asyncAction)
+            where TInstance : class
+            where TException : Exception
+        {
+            return binder.Add(new AsyncFaultedActionActivity<TInstance, TException>(asyncAction));
+        }
+
+        /// <summary>
         /// Adds an asynchronous delegate activity to the event's behavior
         /// </summary>
         /// <typeparam name="TInstance">The state machine instance type</typeparam>
@@ -78,6 +93,23 @@ namespace Automatonymous
             where TException : Exception
         {
             return binder.Add(new FaultedActionActivity<TInstance, TData, TException>(action));
+        }
+
+        /// <summary>
+        /// Adds a asynchronous delegate activity to the event's behavior
+        /// </summary>
+        /// <typeparam name="TInstance">The state machine instance type</typeparam>
+        /// <typeparam name="TException">The exception type</typeparam>
+        /// <typeparam name="TData">The event data type</typeparam>
+        /// <param name="binder">The event binder</param>
+        /// <param name="asyncAction">The asynchronous delegate</param>
+        public static ExceptionActivityBinder<TInstance, TData, TException> ThenAsync<TInstance, TData, TException>(
+            this ExceptionActivityBinder<TInstance, TData, TException> binder,
+            Func<BehaviorExceptionContext<TInstance, TData, TException>, Task> asyncAction)
+            where TInstance : class
+            where TException : Exception
+        {
+            return binder.Add(new AsyncFaultedActionActivity<TInstance, TData, TException>(asyncAction));
         }
 
         /// <summary>


### PR DESCRIPTION
Hi Chris,

I mentioned my problem on MassTransit's Discord channel about setting respond message's request id. Would you consider add this feature?

Regards.
