### PR TITLE
Made it possible to assign a composite event to a specific state.

### DIFF
--- a/src/Automatonymous.Visualizer/StateMachineGraphGenerator.cs
+++ b/src/Automatonymous.Visualizer/StateMachineGraphGenerator.cs
@@ -14,55 +14,46 @@
 
         public StateMachineGraphvizGenerator(StateMachineGraph data)
         {
-            _graph = CreateAdjacencyGraph(data);
+            _graph = new AdjacencyGraph<Vertex, Edge<Vertex>>();
+            _graph.AddVertexRange(data.Vertices);
+            _graph.AddEdgeRange(data.Edges.Select(x => new Edge<Vertex>(x.From, x.To)));
         }
 
         public string CreateDotFile()
         {
             var algorithm = new GraphvizAlgorithm<Vertex, Edge<Vertex>>(_graph);
-            algorithm.FormatVertex += VertexStyler;
-            return algorithm.Generate();
-        }
-
-        static void VertexStyler(object sender, FormatVertexEventArgs<Vertex> args)
-        {
-            args.VertexFormat.Label = args.Vertex.Title;
-
-            if (args.Vertex.VertexType == typeof(Event))
+            algorithm.FormatVertex += (sender, args) =>
             {
-                args.VertexFormat.FontColor = GraphvizColor.Black;
-                args.VertexFormat.Shape = GraphvizVertexShape.Rectangle;
+                args.VertexFormat.Label = args.Vertex.Title;
 
-                if (args.Vertex.TargetType != typeof(Event) && args.Vertex.TargetType != typeof(Exception))
-                    args.VertexFormat.Label += "<" + args.Vertex.TargetType.Name + ">";
-            }
-            else
-            {
-                switch (args.Vertex.Title)
+                if (args.Vertex.VertexType == typeof(Event))
                 {
-                    case "Initial":
-                        args.VertexFormat.FillColor = GraphvizColor.White;
-                        break;
-                    case "Final":
-                        args.VertexFormat.FillColor = GraphvizColor.White;
-                        break;
-                    default:
-                        args.VertexFormat.FillColor = GraphvizColor.White;
-                        args.VertexFormat.FontColor = GraphvizColor.Black;
-                        break;
+                    args.VertexFormat.FontColor = GraphvizColor.Black;
+                    args.VertexFormat.Shape = GraphvizVertexShape.Rectangle;
+
+                    if (args.Vertex.TargetType != typeof(Event) && args.Vertex.TargetType != typeof(Exception))
+                        args.VertexFormat.Label += "<" + args.Vertex.TargetType.Name + ">";
                 }
+                else
+                {
+                    switch (args.Vertex.Title)
+                    {
+                        case "Initial":
+                            args.VertexFormat.FillColor = GraphvizColor.White;
+                            break;
+                        case "Final":
+                            args.VertexFormat.FillColor = GraphvizColor.White;
+                            break;
+                        default:
+                            args.VertexFormat.FillColor = GraphvizColor.White;
+                            args.VertexFormat.FontColor = GraphvizColor.Black;
+                            break;
+                    }
 
-                args.VertexFormat.Shape = GraphvizVertexShape.Ellipse;
-            }
-        }
-
-        static AdjacencyGraph<Vertex, Edge<Vertex>> CreateAdjacencyGraph(StateMachineGraph data)
-        {
-            var graph = new AdjacencyGraph<Vertex, Edge<Vertex>>();
-
-            graph.AddVertexRange(data.Vertices);
-            graph.AddEdgeRange(data.Edges.Select(x => new Edge<Vertex>(x.From, x.To)));
-            return graph;
+                    args.VertexFormat.Shape = GraphvizVertexShape.Ellipse;
+                }
+            };
+            return algorithm.Generate();
         }
     }
 }

--- a/src/Automatonymous/Accessors/DefaultInstanceStateAccessor.cs
+++ b/src/Automatonymous/Accessors/DefaultInstanceStateAccessor.cs
@@ -31,25 +31,17 @@ namespace Automatonymous.Accessors
             _accessor = new Lazy<StateAccessor<TInstance>>(CreateDefaultAccessor);
         }
 
-        Task<State<TInstance>> StateAccessor<TInstance>.Get(InstanceContext<TInstance> context)
-        {
-            return _accessor.Value.Get(context);
-        }
+        Task<State<TInstance>> StateAccessor<TInstance>.Get(InstanceContext<TInstance> context) =>
+            _accessor.Value.Get(context);
 
-        Task StateAccessor<TInstance>.Set(InstanceContext<TInstance> context, State<TInstance> state)
-        {
-            return _accessor.Value.Set(context, state);
-        }
+        Task StateAccessor<TInstance>.Set(InstanceContext<TInstance> context, State<TInstance> state) =>
+            _accessor.Value.Set(context, state);
 
-        public Expression<Func<TInstance, bool>> GetStateExpression(params State[] states)
-        {
-            return _accessor.Value.GetStateExpression(states);
-        }
+        public Expression<Func<TInstance, bool>> GetStateExpression(params State[] states) =>
+            _accessor.Value.GetStateExpression(states);
 
-        public void Probe(ProbeContext context)
-        {
+        public void Probe(ProbeContext context) =>
             _accessor.Value.Probe(context);
-        }
 
         StateAccessor<TInstance> CreateDefaultAccessor()
         {
@@ -69,12 +61,10 @@ namespace Automatonymous.Accessors
                     "The InstanceState was not configured, and no public State property exists.");
 
             var instance = Expression.Parameter(typeof(TInstance), "instance");
-            var memberExpression = Expression.Property(instance, states[0]);
-
-            var expression = Expression.Lambda<Func<TInstance, State>>(memberExpression,
-                instance);
-
-            return new InitialIfNullStateAccessor<TInstance>(_initialState, new RawStateAccessor<TInstance>(_machine, expression, _observer));
+            return new InitialIfNullStateAccessor<TInstance>(_initialState, new RawStateAccessor<TInstance>(
+                _machine,
+                Expression.Lambda<Func<TInstance, State>>(Expression.Property(instance, states[0]), instance),
+                _observer));
         }
     }
 }

--- a/src/Automatonymous/Accessors/InitialIfNullStateAccessor.cs
+++ b/src/Automatonymous/Accessors/InitialIfNullStateAccessor.cs
@@ -19,9 +19,7 @@
         public InitialIfNullStateAccessor(State<TInstance> initialState, StateAccessor<TInstance> stateAccessor)
         {
             _stateAccessor = stateAccessor;
-
-            Activity<TInstance> initialActivity = new TransitionActivity<TInstance>(initialState, _stateAccessor);
-            _initialBehavior = new LastBehavior<TInstance>(initialActivity);
+            _initialBehavior = new LastBehavior<TInstance>(new TransitionActivity<TInstance>(initialState, _stateAccessor));
         }
 
         async Task<State<TInstance>> StateAccessor<TInstance>.Get(InstanceContext<TInstance> context)
@@ -29,28 +27,19 @@
             var state = await _stateAccessor.Get(context).ConfigureAwait(false);
             if (state == null)
             {
-                var behaviorContext = new EventBehaviorContext<TInstance>(context);
-
-                await _initialBehavior.Execute(behaviorContext).ConfigureAwait(false);
-
+                await _initialBehavior.Execute(new EventBehaviorContext<TInstance>(context)).ConfigureAwait(false);
                 state = await _stateAccessor.Get(context).ConfigureAwait(false);
             }
             return state;
         }
 
-        Task StateAccessor<TInstance>.Set(InstanceContext<TInstance> context, State<TInstance> state)
-        {
-            return _stateAccessor.Set(context, state);
-        }
+        Task StateAccessor<TInstance>.Set(InstanceContext<TInstance> context, State<TInstance> state) =>
+            _stateAccessor.Set(context, state);
 
-        public Expression<Func<TInstance, bool>> GetStateExpression(params State[] states)
-        {
-            return _stateAccessor.GetStateExpression(states);
-        }
+        public Expression<Func<TInstance, bool>> GetStateExpression(params State[] states) =>
+            _stateAccessor.GetStateExpression(states);
 
-        public void Probe(ProbeContext context)
-        {
+        public void Probe(ProbeContext context) =>
             _stateAccessor.Probe(context);
-        }
     }
 }

--- a/src/Automatonymous/Accessors/IntCompositeEventStatusAccessor.cs
+++ b/src/Automatonymous/Accessors/IntCompositeEventStatusAccessor.cs
@@ -15,19 +15,13 @@ namespace Automatonymous.Accessors
             _property = new ReadWriteProperty<TInstance, int>(propertyInfo);
         }
 
-        public CompositeEventStatus Get(TInstance instance)
-        {
-            return new CompositeEventStatus(_property.Get(instance));
-        }
+        public CompositeEventStatus Get(TInstance instance) =>
+            new CompositeEventStatus(_property.Get(instance));
 
-        public void Set(TInstance instance, CompositeEventStatus status)
-        {
+        public void Set(TInstance instance, CompositeEventStatus status) =>
             _property.Set(instance, status.Bits);
-        }
 
-        public void Probe(ProbeContext context)
-        {
+        public void Probe(ProbeContext context) =>
             context.Add("property", _property.Property.Name);
-        }
     }
 }

--- a/src/Automatonymous/Accessors/StateAccessorIndex.cs
+++ b/src/Automatonymous/Accessors/StateAccessorIndex.cs
@@ -14,9 +14,7 @@ namespace Automatonymous.Accessors
         public StateAccessorIndex(StateMachine<TInstance> stateMachine, State<TInstance> initial, State<TInstance> final, State[] states)
         {
             _stateMachine = stateMachine;
-
             _assignedStates = new[] {null, initial, final}.Concat(states.Cast<State<TInstance>>()).ToArray();
-
             _states = new Lazy<State<TInstance>[]>(CreateStateArray);
         }
 
@@ -35,20 +33,10 @@ namespace Automatonymous.Accessors
             }
         }
 
-        public State<TInstance> this[int index]
-        {
-            get
-            {
-                if (index < 0 || index >= _states.Value.Length)
-                    throw new ArgumentOutOfRangeException(nameof(index));
+        public State<TInstance> this[int index] =>
+            index < 0 || index >= _states.Value.Length ? throw new ArgumentOutOfRangeException(nameof(index)) : _states.Value[index];
 
-                return _states.Value[index];
-            }
-        }
-
-        State<TInstance>[] CreateStateArray()
-        {
-            return _assignedStates.Concat(_stateMachine.States.Cast<State<TInstance>>()).Distinct().ToArray();
-        }
+        State<TInstance>[] CreateStateArray() =>
+            _assignedStates.Concat(_stateMachine.States.Cast<State<TInstance>>()).Distinct().ToArray();
     }
 }

--- a/src/Automatonymous/Accessors/StructCompositeEventStatusAccessor.cs
+++ b/src/Automatonymous/Accessors/StructCompositeEventStatusAccessor.cs
@@ -5,8 +5,7 @@ namespace Automatonymous.Accessors
     using GreenPipes.Internals.Reflection;
 
 
-    public class StructCompositeEventStatusAccessor<TInstance> :
-        CompositeEventStatusAccessor<TInstance>
+    public class StructCompositeEventStatusAccessor<TInstance> : CompositeEventStatusAccessor<TInstance>
     {
         readonly ReadWriteProperty<TInstance, CompositeEventStatus> _property;
 
@@ -15,19 +14,13 @@ namespace Automatonymous.Accessors
             _property = new ReadWriteProperty<TInstance, CompositeEventStatus>(propertyInfo);
         }
 
-        public CompositeEventStatus Get(TInstance instance)
-        {
-            return _property.Get(instance);
-        }
+        public CompositeEventStatus Get(TInstance instance) =>
+            _property.Get(instance);
 
-        public void Set(TInstance instance, CompositeEventStatus status)
-        {
+        public void Set(TInstance instance, CompositeEventStatus status) =>
             _property.Set(instance, status);
-        }
 
-        public void Probe(ProbeContext context)
-        {
+        public void Probe(ProbeContext context) =>
             context.Add("property", _property.Property.Name);
-        }
     }
 }

--- a/src/Automatonymous/Automatonymous.csproj
+++ b/src/Automatonymous/Automatonymous.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../../Automatonymous.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);1701;1702;1705;1591;1712</NoWarn>
@@ -15,5 +16,21 @@
   <ItemGroup>
     <PackageReference Include="GreenPipes" Version="4.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="AutomatonymousStateMachine.CompositeEvent.cs">
+      <DependentUpon>AutomatonymousStateMachine.cs</DependentUpon>
+    </Compile>
+    <Compile Update="RaiseEventExtensions.cs">
+      <DependentUpon>RaiseEventExtensions.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="RaiseEventExtensions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>RaiseEventExtensions.cs</LastGenOutput>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/Automatonymous/AutomatonymousStateMachine.CompositeEvent.cs
+++ b/src/Automatonymous/AutomatonymousStateMachine.CompositeEvent.cs
@@ -1,0 +1,196 @@
+﻿namespace Automatonymous
+{
+    using System;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using Accessors;
+    using Activities;
+    using Events;
+    using GreenPipes.Internals.Extensions;
+
+
+    public abstract partial class AutomatonymousStateMachine<TInstance>
+        where TInstance : class
+    {
+        private Func<State<TInstance>, CompositeEventOptions, bool> DefaultFilter =>
+            (state, options) => options.HasFlag(CompositeEventOptions.IncludeInitial) || !Equals(state, Initial);
+
+        /// <summary>
+        /// Adds a composite event to the state machine. A composite event is triggered when all
+        /// off the required events have been raised. Note that required events cannot be in the initial
+        /// state since it would cause extra instances of the state machine to be created
+        /// </summary>
+        /// <param name="propertyExpression">The composite event</param>
+        /// <param name="trackingPropertyExpression">The property in the instance used to track the state of the composite event</param>
+        /// <param name="events">The events that must be raised before the composite event is raised</param>
+        protected internal virtual void CompositeEvent(Expression<Func<Event>> propertyExpression,
+            Expression<Func<TInstance, CompositeEventStatus>> trackingPropertyExpression,
+            params Event[] events) =>
+                CompositeEvent(propertyExpression, trackingPropertyExpression, CompositeEventOptions.None, events);
+
+        /// <summary>
+        /// Adds a composite event to the state machine. A composite event is triggered when all
+        /// off the required events have been raised. Note that required events cannot be in the initial
+        /// state since it would cause extra instances of the state machine to be created
+        /// </summary>
+        /// <param name="propertyExpression">The composite event</param>
+        /// <param name="trackingPropertyExpression">The property in the instance used to track the state of the composite event</param>
+        /// <param name="options">Options on the composite event</param>
+        /// <param name="events">The events that must be raised before the composite event is raised</param>
+        protected internal virtual void CompositeEvent(Expression<Func<Event>> propertyExpression,
+            Expression<Func<TInstance, CompositeEventStatus>> trackingPropertyExpression,
+            CompositeEventOptions options,
+            params Event[] events) =>
+                CompositeEvent(propertyExpression, x => DefaultFilter(x, options), trackingPropertyExpression, events);
+
+        /// <summary>
+        /// Adds a composite event to the state machine. A composite event is triggered when all
+        /// off the required events have been raised. Note that required events cannot be in the initial
+        /// state since it would cause extra instances of the state machine to be created.
+        /// Using the assignToStatesFilter allows one to assign the composite event to one or more specific states in stead of the composite
+        /// event being assigned to every state in the state machine.
+        /// </summary>
+        /// <param name="propertyExpression">The composite event</param>
+        /// <param name="assignToStatesFilter">Filter to apply on the state machine states</param>
+        /// <param name="trackingPropertyExpression">The property in the instance used to track the state of the composite event</param>
+        /// <param name="events">The events that must be raised before the composite event is raised</param>
+        protected internal virtual void CompositeEvent(
+            Expression<Func<Event>> propertyExpression,
+            Func<State<TInstance>, bool> assignToStatesFilter,
+            Expression<Func<TInstance, CompositeEventStatus>> trackingPropertyExpression,
+            params Event[] events) => CompositeEvent(() =>
+            {
+                var eventProperty = propertyExpression.GetPropertyInfo();
+                return ConfigurationHelpers.InitializeEvent(this, eventProperty, new TriggerEvent(eventProperty.Name, true));
+            }, new StructCompositeEventStatusAccessor<TInstance>(trackingPropertyExpression.GetPropertyInfo()), events, assignToStatesFilter);
+
+        /// <summary>
+        /// Adds a composite event to the state machine. A composite event is triggered when all
+        /// off the required events have been raised. Note that required events cannot be in the initial
+        /// state since it would cause extra instances of the state machine to be created
+        /// </summary>
+        /// <param name="propertyExpression">The composite event</param>
+        /// <param name="trackingPropertyExpression">The property in the instance used to track the state of the composite event</param>
+        /// <param name="events">The events that must be raised before the composite event is raised</param>
+        protected internal virtual void CompositeEvent(Expression<Func<Event>> propertyExpression,
+            Expression<Func<TInstance, int>> trackingPropertyExpression,
+            params Event[] events) =>
+                CompositeEvent(propertyExpression, x => DefaultFilter(x, CompositeEventOptions.None), trackingPropertyExpression, events);
+
+        protected internal virtual void CompositeEvent(Expression<Func<Event>> propertyExpression,
+            Func<State<TInstance>, bool> assignToStatesFilter,
+            Expression<Func<TInstance, int>> trackingPropertyExpression,
+            params Event[] events) => CompositeEvent(() =>
+            {
+                var eventProperty = propertyExpression.GetPropertyInfo();
+                return ConfigurationHelpers.InitializeEvent(this, eventProperty, new TriggerEvent(eventProperty.Name, true));
+            }, new IntCompositeEventStatusAccessor<TInstance>(trackingPropertyExpression.GetPropertyInfo()), events, assignToStatesFilter);
+
+        /// <summary>
+        /// Adds a composite event to the state machine. A composite event is triggered when all
+        /// off the required events have been raised. Note that required events cannot be in the initial
+        /// state since it would cause extra instances of the state machine to be created
+        /// </summary>
+        /// <param name="propertyExpression">The composite event</param>
+        /// <param name="trackingPropertyExpression">The property in the instance used to track the state of the composite event</param>
+        /// <param name="options">Options on the composite event</param>
+        /// <param name="events">The events that must be raised before the composite event is raised</param>
+        protected internal virtual void CompositeEvent(Expression<Func<Event>> propertyExpression,
+            Expression<Func<TInstance, int>> trackingPropertyExpression,
+            CompositeEventOptions options,
+            params Event[] events) => CompositeEvent(() =>
+            {
+                var eventProperty = propertyExpression.GetPropertyInfo();
+                return ConfigurationHelpers.InitializeEvent(this, eventProperty, new TriggerEvent(eventProperty.Name, true));
+            }, new IntCompositeEventStatusAccessor<TInstance>(trackingPropertyExpression.GetPropertyInfo()), events, x => DefaultFilter(x, options));
+
+        internal virtual void CompositeEvent(string name,
+            Expression<Func<TInstance, CompositeEventStatus>> trackingPropertyExpression,
+            params Event[] events) =>
+                CompositeEvent(name, trackingPropertyExpression, CompositeEventOptions.None, events);
+
+        internal virtual Event CompositeEvent(string name,
+            Expression<Func<TInstance, CompositeEventStatus>> trackingPropertyExpression,
+            CompositeEventOptions options,
+            params Event[] events) =>
+                CompositeEvent(name, new StructCompositeEventStatusAccessor<TInstance>(trackingPropertyExpression.GetPropertyInfo()), options, events);
+
+        internal virtual Event CompositeEvent(string name,
+            Expression<Func<TInstance, int>> trackingPropertyExpression,
+            params Event[] events) =>
+                CompositeEvent(name, trackingPropertyExpression, CompositeEventOptions.None, events);
+
+        internal virtual Event CompositeEvent(string name,
+            Expression<Func<TInstance, int>> trackingPropertyExpression,
+            CompositeEventOptions options,
+            params Event[] events) =>
+                CompositeEvent(name, new IntCompositeEventStatusAccessor<TInstance>(trackingPropertyExpression.GetPropertyInfo()), options, events);
+
+        protected internal virtual void CompositeEvent(Event @event,
+            Expression<Func<TInstance, CompositeEventStatus>> trackingPropertyExpression,
+            params Event[] events) =>
+                CompositeEvent(@event, trackingPropertyExpression, CompositeEventOptions.None, events);
+
+        protected internal virtual Event CompositeEvent(Event @event,
+            Expression<Func<TInstance, CompositeEventStatus>> trackingPropertyExpression,
+            CompositeEventOptions options,
+            params Event[] events) =>
+                CompositeEvent(() => @event, new StructCompositeEventStatusAccessor<TInstance>(trackingPropertyExpression.GetPropertyInfo()), events, x => DefaultFilter(x, options));
+
+        protected internal virtual Event CompositeEvent(Event @event,
+            Expression<Func<TInstance, int>> trackingPropertyExpression,
+            params Event[] events) => CompositeEvent(@event, trackingPropertyExpression, CompositeEventOptions.None, events);
+
+        protected internal virtual Event CompositeEvent(Event @event,
+            Expression<Func<TInstance, int>> trackingPropertyExpression,
+            CompositeEventOptions options,
+            params Event[] events) =>
+                CompositeEvent(() => @event, new IntCompositeEventStatusAccessor<TInstance>(trackingPropertyExpression.GetPropertyInfo()), events, x => DefaultFilter(x, options));
+
+        private Event CompositeEvent(string name, CompositeEventStatusAccessor<TInstance> accessor, CompositeEventOptions options, Event[] events) =>
+            CompositeEvent(() =>
+            {
+                var @event = new TriggerEvent(name, true);
+                _eventCache[name] = new StateMachineEvent(@event, false);
+                return @event;
+            }, accessor, events, x => DefaultFilter(x, options));
+
+        private Event CompositeEvent(Func<Event> getEventFunc, CompositeEventStatusAccessor<TInstance> accessor, Event[] events, Func<State<TInstance>, bool> filter = null)
+        {
+            if (events == null)
+            {
+                throw new ArgumentNullException(nameof(events));
+            }
+            if (events.Length > 31)
+            {
+                throw new ArgumentException("No more than 31 events can be combined into a single event");
+            }
+            if (events.Length == 0)
+            {
+                throw new ArgumentException("At least one event must be specified for a composite event");
+            }
+            if (events.Any(x => x == null))
+            {
+                throw new ArgumentException("One or more events specified has not yet been initialized");
+            }
+
+            var complete = new CompositeEventStatus(Enumerable.Range(0, events.Length).Aggregate(0, (current, x) => current | (1 << x)));
+            var @event = getEventFunc();
+            @event.IsComposite = true;
+            _eventCache[@event.Name].Event = @event;
+            for (var i = 0; i < events.Length; i++)
+            {
+                var flag = 1 << i;
+                var activity = new CompositeEventActivity<TInstance>(accessor, flag, complete, @event);
+
+                var states = _stateCache.Values.Where(x => filter?.Invoke(x) ?? !Equals(x, Initial));
+                foreach (var state in states)
+                {
+                    During(state, When(events[i]).Execute(activity));
+                }
+            }
+
+            return @event;
+        }
+    }
+}

--- a/src/Automatonymous/Binders/TriggerEventActivityBinder.cs
+++ b/src/Automatonymous/Binders/TriggerEventActivityBinder.cs
@@ -10,34 +10,27 @@ namespace Automatonymous.Binders
         where TInstance : class
     {
         readonly ActivityBinder<TInstance>[] _activities;
-        readonly Event _event;
         readonly StateMachineEventFilter<TInstance> _filter;
         readonly StateMachine<TInstance> _machine;
+        readonly Event _event;
 
         public TriggerEventActivityBinder(StateMachine<TInstance> machine, Event @event, params ActivityBinder<TInstance>[] activities)
         {
             _event = @event;
             _machine = machine;
-            _activities = activities ?? new ActivityBinder<TInstance>[0];
+            _activities = activities ?? Array.Empty<ActivityBinder<TInstance>>();
         }
 
         public TriggerEventActivityBinder(StateMachine<TInstance> machine, Event @event, StateMachineEventFilter<TInstance> filter,
-            params ActivityBinder<TInstance>[] activities)
+            params ActivityBinder<TInstance>[] activities) : this(machine, @event, activities)
         {
-            _event = @event;
             _filter = filter;
-            _machine = machine;
-            _activities = activities ?? new ActivityBinder<TInstance>[0];
         }
 
         TriggerEventActivityBinder(StateMachine<TInstance> machine, Event @event, StateMachineEventFilter<TInstance> filter,
             ActivityBinder<TInstance>[] activities,
-            params ActivityBinder<TInstance>[] appendActivity)
+            params ActivityBinder<TInstance>[] appendActivity) : this(machine, @event, filter, activities)
         {
-            _event = @event;
-            _filter = filter;
-            _machine = machine;
-
             _activities = new ActivityBinder<TInstance>[activities.Length + appendActivity.Length];
             Array.Copy(activities, 0, _activities, 0, activities.Length);
             Array.Copy(appendActivity, 0, _activities, activities.Length, appendActivity.Length);
@@ -45,86 +38,49 @@ namespace Automatonymous.Binders
 
         Event EventActivityBinder<TInstance>.Event => _event;
 
-        EventActivityBinder<TInstance> EventActivityBinder<TInstance>.Add(Activity<TInstance> activity)
-        {
-            ActivityBinder<TInstance> activityBinder = new ExecuteActivityBinder<TInstance>(_event, activity);
-
-            return new TriggerEventActivityBinder<TInstance>(_machine, _event, _filter, _activities, activityBinder);
-        }
+        EventActivityBinder<TInstance> EventActivityBinder<TInstance>.Add(Activity<TInstance> activity) =>
+            new TriggerEventActivityBinder<TInstance>(_machine, _event, _filter, _activities, new ExecuteActivityBinder<TInstance>(_event, activity));
 
         EventActivityBinder<TInstance> EventActivityBinder<TInstance>.Catch<T>(
             Func<ExceptionActivityBinder<TInstance, T>, ExceptionActivityBinder<TInstance, T>> activityCallback)
         {
             ExceptionActivityBinder<TInstance, T> binder = new CatchExceptionActivityBinder<TInstance, T>(_machine, _event);
-
             binder = activityCallback(binder);
-
-            ActivityBinder<TInstance> activityBinder = new CatchActivityBinder<TInstance, T>(_event, binder);
-
-            return new TriggerEventActivityBinder<TInstance>(_machine, _event, _filter, _activities, activityBinder);
+            return new TriggerEventActivityBinder<TInstance>(_machine, _event, _filter, _activities, new CatchActivityBinder<TInstance, T>(_event, binder));
         }
 
         EventActivityBinder<TInstance> EventActivityBinder<TInstance>.If(StateMachineCondition<TInstance> condition,
-            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> activityCallback)
-        {
-            return IfElse(condition, activityCallback, _ => _);
-        }
+            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> activityCallback) =>
+                IfElse(condition, activityCallback, _ => _);
 
         EventActivityBinder<TInstance> EventActivityBinder<TInstance>.IfAsync(StateMachineAsyncCondition<TInstance> condition,
-            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> activityCallback)
-        {
-            return IfElseAsync(condition, activityCallback, _ => _);
-        }
+            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> activityCallback) =>
+                IfElseAsync(condition, activityCallback, _ => _);
 
         public EventActivityBinder<TInstance> IfElse(StateMachineCondition<TInstance> condition,
             Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> thenActivityCallback,
-            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> elseActivityCallback)
-        {
-            var thenBinder = GetBinder(thenActivityCallback);
-            var elseBinder = GetBinder(elseActivityCallback);
-
-            var conditionBinder = new ConditionalActivityBinder<TInstance>(_event, condition, thenBinder, elseBinder);
-
-            return new TriggerEventActivityBinder<TInstance>(_machine, _event, _filter, _activities, conditionBinder);
-        }
+            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> elseActivityCallback) =>
+                new TriggerEventActivityBinder<TInstance>(_machine, _event, _filter, _activities,
+                    new ConditionalActivityBinder<TInstance>(_event, condition, GetBinder(thenActivityCallback), GetBinder(elseActivityCallback)));
 
         public EventActivityBinder<TInstance> IfElseAsync(StateMachineAsyncCondition<TInstance> condition,
             Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> thenActivityCallback,
-            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> elseActivityCallback)
-        {
-            var thenBinder = GetBinder(thenActivityCallback);
-            var elseBinder = GetBinder(elseActivityCallback);
-
-            var conditionBinder = new ConditionalActivityBinder<TInstance>(_event, condition, thenBinder, elseBinder);
-
-            return new TriggerEventActivityBinder<TInstance>(_machine, _event, _filter, _activities, conditionBinder);
-        }
+            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> elseActivityCallback) =>
+                new TriggerEventActivityBinder<TInstance>(_machine, _event, _filter, _activities,
+                    new ConditionalActivityBinder<TInstance>(_event, condition, GetBinder(thenActivityCallback), GetBinder(elseActivityCallback)));
 
         StateMachine<TInstance> EventActivityBinder<TInstance>.StateMachine => _machine;
 
-        public IEnumerable<ActivityBinder<TInstance>> GetStateActivityBinders()
-        {
-            if (_filter != null)
-                return Enumerable.Repeat(CreateConditionalActivityBinder(), 1);
-
-            return _activities;
-        }
+        public IEnumerable<ActivityBinder<TInstance>> GetStateActivityBinders() =>
+            _filter != null ? Enumerable.Repeat(CreateConditionalActivityBinder(), 1) : _activities;
 
         EventActivityBinder<TInstance> GetBinder(
-            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> activityCallback)
-        {
-            EventActivityBinder<TInstance> binder = new TriggerEventActivityBinder<TInstance>(_machine, _event);
-            return activityCallback(binder);
-        }
+            Func<EventActivityBinder<TInstance>, EventActivityBinder<TInstance>> activityCallback) =>
+                activityCallback(new TriggerEventActivityBinder<TInstance>(_machine, _event));
 
-        ActivityBinder<TInstance> CreateConditionalActivityBinder()
-        {
-            EventActivityBinder<TInstance> thenBinder = new TriggerEventActivityBinder<TInstance>(_machine, _event, _activities);
-            EventActivityBinder<TInstance> elseBinder = new TriggerEventActivityBinder<TInstance>(_machine, _event);
-
-            var conditionBinder = new ConditionalActivityBinder<TInstance>(_event, context => _filter(context), thenBinder, elseBinder);
-
-            return conditionBinder;
-        }
+        ActivityBinder<TInstance> CreateConditionalActivityBinder() => new ConditionalActivityBinder<TInstance>(_event,
+            context => _filter(context),
+            new TriggerEventActivityBinder<TInstance>(_machine, _event, _activities),
+            new TriggerEventActivityBinder<TInstance>(_machine, _event));
     }
 }

--- a/src/Automatonymous/Event.cs
+++ b/src/Automatonymous/Event.cs
@@ -1,6 +1,7 @@
 namespace Automatonymous
 {
     using System;
+    using Binders;
 
 
     public interface Event :
@@ -8,8 +9,8 @@ namespace Automatonymous
         IComparable<Event>
     {
         string Name { get; }
+        bool IsComposite { get; set;}
     }
-
 
     public interface Event<out TData> :
         Event

--- a/src/Automatonymous/Events/DataEvent.cs
+++ b/src/Automatonymous/Events/DataEvent.cs
@@ -15,44 +15,27 @@ namespace Automatonymous.Events
         {
         }
 
-        public override void Accept(StateMachineVisitor visitor)
-        {
-            visitor.Visit(this, x => { });
-        }
+        public override void Accept(StateMachineVisitor visitor) =>
+            visitor.Visit(this, x =>
+            {
+            });
 
         public override void Probe(ProbeContext context)
         {
             base.Probe(context);
-
             context.Add("dataType", TypeCache<TData>.ShortName);
         }
 
-        public bool Equals(DataEvent<TData> other)
-        {
-            if (ReferenceEquals(null, other))
-                return false;
-            if (ReferenceEquals(this, other))
-                return true;
-            return Equals(other.Name, Name);
-        }
+        public bool Equals(DataEvent<TData> other) =>
+            !ReferenceEquals(null, other) && (ReferenceEquals(this, other) || Equals(other.Name, Name));
 
-        public override string ToString()
-        {
-            return $"{Name}<{typeof(TData).Name}> (Event)";
-        }
+        public override string ToString() =>
+            $"{Name}<{typeof(TData).Name}> (Event)";
 
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            return Equals(obj as DataEvent<TData>);
-        }
+        public override bool Equals(object obj) =>
+            !ReferenceEquals(null, obj) && (ReferenceEquals(this, obj) || Equals(obj as DataEvent<TData>));
 
-        public override int GetHashCode()
-        {
-            return base.GetHashCode() * 27 + typeof(TData).GetHashCode();
-        }
+        public override int GetHashCode() =>
+            base.GetHashCode() * 27 + typeof(TData).GetHashCode();
     }
 }

--- a/src/Automatonymous/Events/StateMachineEvent.cs
+++ b/src/Automatonymous/Events/StateMachineEvent.cs
@@ -1,14 +1,14 @@
 namespace Automatonymous.Events
 {
-    class StateMachineEvent<TInstance>
+    class StateMachineEvent
     {
+        public Event Event { get; set; }
+        public bool IsTransitionEvent { get; }
+
         public StateMachineEvent(Event @event, bool isTransitionEvent)
         {
             Event = @event;
             IsTransitionEvent = isTransitionEvent;
         }
-
-        public bool IsTransitionEvent { get; }
-        public Event Event { get; }
     }
 }

--- a/src/Automatonymous/Events/TriggerEvent.cs
+++ b/src/Automatonymous/Events/TriggerEvent.cs
@@ -4,61 +4,39 @@
     using GreenPipes;
 
 
-    public class TriggerEvent :
-        Event
+    public class TriggerEvent : Event
     {
-        readonly string _name;
 
-        public TriggerEvent(string name)
+        public string Name { get; }
+        public bool IsComposite { get; set; }
+
+        public TriggerEvent(string name, bool isComposite = false)
         {
-            _name = name;
+            Name = name;
+            IsComposite = isComposite;
         }
 
-        public string Name => _name;
+        public virtual void Accept(StateMachineVisitor visitor) =>
+            visitor.Visit(this, x =>
+            {
+            });
 
-        public virtual void Accept(StateMachineVisitor visitor)
-        {
-            visitor.Visit(this, x => { });
-        }
+        public virtual void Probe(ProbeContext context) =>
+            context.Add("name", Name);
 
-        public virtual void Probe(ProbeContext context)
-        {
-            context.Add("name", _name);
-        }
+        public int CompareTo(Event other) =>
+            string.Compare(Name, other.Name, StringComparison.Ordinal);
 
-        public int CompareTo(Event other)
-        {
-            return string.Compare(_name, other.Name, StringComparison.Ordinal);
-        }
+        public bool Equals(TriggerEvent other) =>
+            !ReferenceEquals(null, other) && (ReferenceEquals(this, other) || Equals(other.Name, Name));
 
-        public bool Equals(TriggerEvent other)
-        {
-            if (ReferenceEquals(null, other))
-                return false;
-            if (ReferenceEquals(this, other))
-                return true;
-            return Equals(other._name, _name);
-        }
+        public override bool Equals(object obj) =>
+            !ReferenceEquals(null, obj) && (ReferenceEquals(this, obj) || obj.GetType() == typeof(TriggerEvent) && Equals((TriggerEvent)obj));
 
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != typeof(TriggerEvent))
-                return false;
-            return Equals((TriggerEvent)obj);
-        }
+        public override int GetHashCode() =>
+            Name?.GetHashCode() ?? 0;
 
-        public override int GetHashCode()
-        {
-            return _name?.GetHashCode() ?? 0;
-        }
-
-        public override string ToString()
-        {
-            return $"{_name} (Event)";
-        }
+        public override string ToString() =>
+            $"{Name} (Event)";
     }
 }

--- a/src/Automatonymous/Graphing/Edge.cs
+++ b/src/Automatonymous/Graphing/Edge.cs
@@ -4,8 +4,7 @@ namespace Automatonymous.Graphing
 
 
     [Serializable]
-    public class Edge :
-        IEquatable<Edge>
+    public class Edge : IEquatable<Edge>
     {
         public Edge(Vertex from, Vertex to, string title)
         {
@@ -20,25 +19,13 @@ namespace Automatonymous.Graphing
 
         string Title { get; }
 
-        public bool Equals(Edge other)
-        {
-            if (ReferenceEquals(null, other))
-                return false;
-            if (ReferenceEquals(this, other))
-                return true;
-            return Equals(To, other.To) && Equals(From, other.From) && string.Equals(Title, other.Title);
-        }
+        public bool Equals(Edge other) =>
+            !ReferenceEquals(null, other) && (ReferenceEquals(this, other) || Equals(To, other.To) && Equals(From, other.From) && string.Equals(Title, other.Title));
 
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-            return Equals((Edge)obj);
-        }
+        public override bool Equals(object obj) =>
+            !ReferenceEquals(null, obj) && (ReferenceEquals(this, obj) || obj.GetType() == GetType() && Equals((Edge)obj));
+
+        public override string ToString() => Title;
 
         public override int GetHashCode()
         {

--- a/src/Automatonymous/Graphing/GraphStateMachineExtensions.cs
+++ b/src/Automatonymous/Graphing/GraphStateMachineExtensions.cs
@@ -6,9 +6,7 @@ namespace Automatonymous.Graphing
             where TInstance : class
         {
             var inspector = new GraphStateMachineVisitor<TInstance>();
-
             machine.Accept(inspector);
-
             return inspector.Graph;
         }
     }

--- a/src/Automatonymous/Graphing/StateMachineGraph.cs
+++ b/src/Automatonymous/Graphing/StateMachineGraph.cs
@@ -8,17 +8,14 @@ namespace Automatonymous.Graphing
     [Serializable]
     public class StateMachineGraph
     {
-        readonly Edge[] _edges;
-        readonly Vertex[] _vertices;
+        public IEnumerable<Vertex> Vertices { get; }
+
+        public IEnumerable<Edge> Edges { get; }
 
         public StateMachineGraph(IEnumerable<Vertex> vertices, IEnumerable<Edge> edges)
         {
-            _vertices = vertices.ToArray();
-            _edges = edges.ToArray();
+            Vertices = vertices.ToArray();
+            Edges = edges.ToArray();
         }
-
-        public IEnumerable<Vertex> Vertices => _vertices;
-
-        public IEnumerable<Edge> Edges => _edges;
     }
 }

--- a/src/Automatonymous/Graphing/Vertex.cs
+++ b/src/Automatonymous/Graphing/Vertex.cs
@@ -4,41 +4,31 @@ namespace Automatonymous.Graphing
 
 
     [Serializable]
-    public class Vertex :
-        IEquatable<Vertex>
+    public class Vertex : IEquatable<Vertex>
     {
-        public Vertex(Type type, Type targetType, string title)
+        public Vertex(Type type, Type targetType, string title, bool isComposite)
         {
             VertexType = type;
             TargetType = targetType;
             Title = title;
+            IsComposite = isComposite;
         }
 
         public string Title { get; }
+        public bool IsComposite { get; }
 
         public Type VertexType { get; }
 
         public Type TargetType { get; }
 
-        public bool Equals(Vertex other)
-        {
-            if (ReferenceEquals(null, other))
-                return false;
-            if (ReferenceEquals(this, other))
-                return true;
-            return string.Equals(Title, other.Title) && VertexType == other.VertexType && TargetType == other.TargetType;
-        }
+        public bool Equals(Vertex other) =>
+            !ReferenceEquals(null, other) && (ReferenceEquals(this, other) || string.Equals(Title, other.Title) && VertexType == other.VertexType && TargetType == other.TargetType);
 
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-                return false;
-            if (ReferenceEquals(this, obj))
-                return true;
-            if (obj.GetType() != GetType())
-                return false;
-            return Equals((Vertex)obj);
-        }
+        public override bool Equals(object obj) =>
+            !ReferenceEquals(null, obj) && (ReferenceEquals(this, obj) || obj.GetType() == GetType() && Equals((Vertex)obj));
+
+        public override string ToString() =>
+            Title;
 
         public override int GetHashCode()
         {

--- a/src/Automatonymous/Observers/NonTransitionEventObserver.cs
+++ b/src/Automatonymous/Observers/NonTransitionEventObserver.cs
@@ -10,10 +10,10 @@ namespace Automatonymous.Observers
     class NonTransitionEventObserver<TInstance> :
         EventObserver<TInstance>
     {
-        readonly IReadOnlyDictionary<string, StateMachineEvent<TInstance>> _eventCache;
+        readonly IReadOnlyDictionary<string, StateMachineEvent> _eventCache;
         readonly EventObserver<TInstance> _observer;
 
-        public NonTransitionEventObserver(IReadOnlyDictionary<string, StateMachineEvent<TInstance>> eventCache,
+        public NonTransitionEventObserver(IReadOnlyDictionary<string, StateMachineEvent> eventCache,
             EventObserver<TInstance> observer)
         {
             _eventCache = eventCache;

--- a/src/Automatonymous/RaiseEventExtensions.cs
+++ b/src/Automatonymous/RaiseEventExtensions.cs
@@ -6,7 +6,6 @@
     using System.Threading.Tasks;
     using Contexts;
 
-
     [DebuggerNonUserCode]
     public static class RaiseEventExtensions
     {
@@ -46,10 +45,9 @@
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
             var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
 
@@ -91,16 +89,14 @@
         /// <param name="eventSelector">Selector to the event on the state machine</param>
         /// <param name="data">The event data</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector,
-            TData data,
+        public static Task RaiseEvent<T, TData, TInstance>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
             var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
 
@@ -117,7 +113,7 @@
         /// <param name="event">The event to raise</param>
         /// <param name="context1">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1>(this T machine, TInstance instance, Event @event, T1 context1,
+        public static Task RaiseEvent<T, TInstance,T1>(this T machine, TInstance instance, Event @event, T1 context1,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -126,8 +122,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);
 
             return machine.RaiseEvent(context);
         }
@@ -142,19 +137,17 @@
         /// <param name="eventSelector">Selector to the event on the state machine</param>
         /// <param name="context1">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1,
+        public static Task RaiseEvent<T, TInstance,T1>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
             where T1 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);
 
             return machine.RaiseEvent(context);
         }
@@ -171,8 +164,7 @@
         /// <param name="data">The event data</param>
         /// <param name="context1">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1>(this T machine, TInstance instance, Event<TData> @event, TData data,
-            T1 context1,
+        public static Task RaiseEvent<T, TData, TInstance,T1>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -181,8 +173,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);
 
             return machine.RaiseEvent(context);
         }
@@ -199,24 +190,20 @@
         /// <param name="data">The event data</param>
         /// <param name="context1">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector,
-            TData data, T1 context1,
+        public static Task RaiseEvent<T, TData, TInstance,T1>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
             where T1 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -228,7 +215,7 @@
         /// <param name="context1">An additional context added to the event context</param>
         /// <param name="context2">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2,
+        public static Task RaiseEvent<T, TInstance,T1,T2>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -238,9 +225,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);
 
             return machine.RaiseEvent(context);
         }
@@ -256,22 +241,18 @@
         /// <param name="context1">An additional context added to the event context</param>
         /// <param name="context2">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1,
-            T2 context2,
+        public static Task RaiseEvent<T, TInstance,T1,T2>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
             where T1 : class
             where T2 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);
 
             return machine.RaiseEvent(context);
         }
@@ -289,8 +270,7 @@
         /// <param name="context1">An additional context added to the event context</param>
         /// <param name="context2">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2>(this T machine, TInstance instance, Event<TData> @event, TData data,
-            T1 context1, T2 context2,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -300,9 +280,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);
 
             return machine.RaiseEvent(context);
         }
@@ -320,26 +298,21 @@
         /// <param name="context1">An additional context added to the event context</param>
         /// <param name="context2">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector,
-            TData data, T1 context1, T2 context2,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
             where T1 : class
             where T2 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -352,8 +325,7 @@
         /// <param name="context2">An additional context added to the event context</param>
         /// <param name="context3">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2,
-            T3 context3,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -364,10 +336,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);
 
             return machine.RaiseEvent(context);
         }
@@ -384,8 +353,7 @@
         /// <param name="context2">An additional context added to the event context</param>
         /// <param name="context3">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3>(this T machine, TInstance instance, Func<T, Event> eventSelector,
-            T1 context1, T2 context2, T3 context3,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -393,15 +361,11 @@
             where T2 : class
             where T3 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);
 
             return machine.RaiseEvent(context);
         }
@@ -420,8 +384,7 @@
         /// <param name="context2">An additional context added to the event context</param>
         /// <param name="context3">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3>(this T machine, TInstance instance, Event<TData> @event, TData data,
-            T1 context1, T2 context2, T3 context3,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -432,10 +395,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);
 
             return machine.RaiseEvent(context);
         }
@@ -454,8 +414,7 @@
         /// <param name="context2">An additional context added to the event context</param>
         /// <param name="context3">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3>(this T machine, TInstance instance,
-            Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -463,19 +422,14 @@
             where T2 : class
             where T3 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -489,8 +443,7 @@
         /// <param name="context3">An additional context added to the event context</param>
         /// <param name="context4">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4>(this T machine, TInstance instance, Event @event, T1 context1,
-            T2 context2, T3 context3, T4 context4,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -502,11 +455,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);
 
             return machine.RaiseEvent(context);
         }
@@ -524,8 +473,7 @@
         /// <param name="context3">An additional context added to the event context</param>
         /// <param name="context4">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4>(this T machine, TInstance instance, Func<T, Event> eventSelector,
-            T1 context1, T2 context2, T3 context3, T4 context4,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -534,16 +482,11 @@
             where T3 : class
             where T4 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);
 
             return machine.RaiseEvent(context);
         }
@@ -563,8 +506,7 @@
         /// <param name="context3">An additional context added to the event context</param>
         /// <param name="context4">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4>(this T machine, TInstance instance, Event<TData> @event,
-            TData data, T1 context1, T2 context2, T3 context3, T4 context4,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -576,11 +518,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);
 
             return machine.RaiseEvent(context);
         }
@@ -600,8 +538,7 @@
         /// <param name="context3">An additional context added to the event context</param>
         /// <param name="context4">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4>(this T machine, TInstance instance,
-            Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -610,20 +547,14 @@
             where T3 : class
             where T4 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -638,8 +569,7 @@
         /// <param name="context4">An additional context added to the event context</param>
         /// <param name="context5">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5>(this T machine, TInstance instance, Event @event, T1 context1,
-            T2 context2, T3 context3, T4 context4, T5 context5,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -652,12 +582,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);
 
             return machine.RaiseEvent(context);
         }
@@ -676,8 +601,7 @@
         /// <param name="context4">An additional context added to the event context</param>
         /// <param name="context5">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5>(this T machine, TInstance instance, Func<T, Event> eventSelector,
-            T1 context1, T2 context2, T3 context3, T4 context4, T5 context5,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -687,17 +611,11 @@
             where T4 : class
             where T5 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);
 
             return machine.RaiseEvent(context);
         }
@@ -718,8 +636,7 @@
         /// <param name="context4">An additional context added to the event context</param>
         /// <param name="context5">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5>(this T machine, TInstance instance, Event<TData> @event,
-            TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -732,12 +649,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);
 
             return machine.RaiseEvent(context);
         }
@@ -758,8 +670,7 @@
         /// <param name="context4">An additional context added to the event context</param>
         /// <param name="context5">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5>(this T machine, TInstance instance,
-            Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -769,21 +680,14 @@
             where T4 : class
             where T5 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -799,8 +703,7 @@
         /// <param name="context5">An additional context added to the event context</param>
         /// <param name="context6">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6>(this T machine, TInstance instance, Event @event, T1 context1,
-            T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -814,13 +717,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);
 
             return machine.RaiseEvent(context);
         }
@@ -840,8 +737,7 @@
         /// <param name="context5">An additional context added to the event context</param>
         /// <param name="context6">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6>(this T machine, TInstance instance, Func<T, Event> eventSelector,
-            T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -852,18 +748,11 @@
             where T5 : class
             where T6 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);
 
             return machine.RaiseEvent(context);
         }
@@ -885,8 +774,7 @@
         /// <param name="context5">An additional context added to the event context</param>
         /// <param name="context6">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6>(this T machine, TInstance instance, Event<TData> @event,
-            TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -900,13 +788,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);
 
             return machine.RaiseEvent(context);
         }
@@ -928,8 +810,7 @@
         /// <param name="context5">An additional context added to the event context</param>
         /// <param name="context6">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6>(this T machine, TInstance instance,
-            Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -940,22 +821,14 @@
             where T5 : class
             where T6 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -972,8 +845,7 @@
         /// <param name="context6">An additional context added to the event context</param>
         /// <param name="context7">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7>(this T machine, TInstance instance, Event @event,
-            T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -988,14 +860,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);
 
             return machine.RaiseEvent(context);
         }
@@ -1016,8 +881,7 @@
         /// <param name="context6">An additional context added to the event context</param>
         /// <param name="context7">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7>(this T machine, TInstance instance,
-            Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1029,19 +893,11 @@
             where T6 : class
             where T7 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);
 
             return machine.RaiseEvent(context);
         }
@@ -1064,8 +920,7 @@
         /// <param name="context6">An additional context added to the event context</param>
         /// <param name="context7">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7>(this T machine, TInstance instance,
-            Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1080,14 +935,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);
 
             return machine.RaiseEvent(context);
         }
@@ -1110,9 +958,7 @@
         /// <param name="context6">An additional context added to the event context</param>
         /// <param name="context7">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7>(this T machine, TInstance instance,
-            Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
-            T7 context7,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1124,23 +970,14 @@
             where T6 : class
             where T7 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -1158,8 +995,7 @@
         /// <param name="context7">An additional context added to the event context</param>
         /// <param name="context8">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8>(this T machine, TInstance instance, Event @event,
-            T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1175,15 +1011,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);
 
             return machine.RaiseEvent(context);
         }
@@ -1205,9 +1033,7 @@
         /// <param name="context7">An additional context added to the event context</param>
         /// <param name="context8">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8>(this T machine, TInstance instance,
-            Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
-            T8 context8,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1220,20 +1046,11 @@
             where T7 : class
             where T8 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);
 
             return machine.RaiseEvent(context);
         }
@@ -1257,9 +1074,7 @@
         /// <param name="context7">An additional context added to the event context</param>
         /// <param name="context8">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8>(this T machine, TInstance instance,
-            Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
-            T8 context8,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1275,15 +1090,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);
 
             return machine.RaiseEvent(context);
         }
@@ -1307,9 +1114,7 @@
         /// <param name="context7">An additional context added to the event context</param>
         /// <param name="context8">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8>(this T machine, TInstance instance,
-            Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
-            T7 context7, T8 context8,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1322,24 +1127,14 @@
             where T7 : class
             where T8 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -1358,8 +1153,7 @@
         /// <param name="context8">An additional context added to the event context</param>
         /// <param name="context9">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this T machine, TInstance instance, Event @event,
-            T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1376,16 +1170,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);
 
             return machine.RaiseEvent(context);
         }
@@ -1408,9 +1193,7 @@
         /// <param name="context8">An additional context added to the event context</param>
         /// <param name="context9">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this T machine, TInstance instance,
-            Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
-            T8 context8, T9 context9,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1424,21 +1207,11 @@
             where T8 : class
             where T9 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);
 
             return machine.RaiseEvent(context);
         }
@@ -1463,9 +1236,7 @@
         /// <param name="context8">An additional context added to the event context</param>
         /// <param name="context9">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this T machine, TInstance instance,
-            Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
-            T8 context8, T9 context9,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1482,16 +1253,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);
 
             return machine.RaiseEvent(context);
         }
@@ -1516,9 +1278,7 @@
         /// <param name="context8">An additional context added to the event context</param>
         /// <param name="context9">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this T machine, TInstance instance,
-            Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
-            T7 context7, T8 context8, T9 context9,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1532,25 +1292,14 @@
             where T8 : class
             where T9 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -1570,9 +1319,7 @@
         /// <param name="context9">An additional context added to the event context</param>
         /// <param name="context10">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this T machine, TInstance instance,
-            Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8,
-            T9 context9, T10 context10,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1590,17 +1337,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);
 
             return machine.RaiseEvent(context);
         }
@@ -1624,9 +1361,7 @@
         /// <param name="context9">An additional context added to the event context</param>
         /// <param name="context10">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this T machine, TInstance instance,
-            Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
-            T8 context8, T9 context9, T10 context10,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1641,22 +1376,11 @@
             where T9 : class
             where T10 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);
 
             return machine.RaiseEvent(context);
         }
@@ -1682,9 +1406,7 @@
         /// <param name="context9">An additional context added to the event context</param>
         /// <param name="context10">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this T machine, TInstance instance,
-            Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
-            T8 context8, T9 context9, T10 context10,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1702,17 +1424,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);
 
             return machine.RaiseEvent(context);
         }
@@ -1738,9 +1450,7 @@
         /// <param name="context9">An additional context added to the event context</param>
         /// <param name="context10">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this T machine, TInstance instance,
-            Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
-            T7 context7, T8 context8, T9 context9, T10 context10,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1755,26 +1465,14 @@
             where T9 : class
             where T10 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -1795,9 +1493,7 @@
         /// <param name="context10">An additional context added to the event context</param>
         /// <param name="context11">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this T machine, TInstance instance,
-            Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8,
-            T9 context9, T10 context10, T11 context11,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1816,18 +1512,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);
 
             return machine.RaiseEvent(context);
         }
@@ -1852,9 +1537,7 @@
         /// <param name="context10">An additional context added to the event context</param>
         /// <param name="context11">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this T machine, TInstance instance,
-            Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
-            T8 context8, T9 context9, T10 context10, T11 context11,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1870,23 +1553,11 @@
             where T10 : class
             where T11 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);
 
             return machine.RaiseEvent(context);
         }
@@ -1913,9 +1584,7 @@
         /// <param name="context10">An additional context added to the event context</param>
         /// <param name="context11">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this T machine, TInstance instance,
-            Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
-            T8 context8, T9 context9, T10 context10, T11 context11,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1934,18 +1603,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);
 
             return machine.RaiseEvent(context);
         }
@@ -1972,9 +1630,7 @@
         /// <param name="context10">An additional context added to the event context</param>
         /// <param name="context11">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this T machine, TInstance instance,
-            Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
-            T7 context7, T8 context8, T9 context9, T10 context10, T11 context11,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -1990,27 +1646,14 @@
             where T10 : class
             where T11 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -2032,9 +1675,7 @@
         /// <param name="context11">An additional context added to the event context</param>
         /// <param name="context12">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this T machine, TInstance instance,
-            Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8,
-            T9 context9, T10 context10, T11 context11, T12 context12,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2054,19 +1695,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);
 
             return machine.RaiseEvent(context);
         }
@@ -2092,9 +1721,7 @@
         /// <param name="context11">An additional context added to the event context</param>
         /// <param name="context12">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this T machine, TInstance instance,
-            Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
-            T8 context8, T9 context9, T10 context10, T11 context11, T12 context12,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2111,24 +1738,11 @@
             where T11 : class
             where T12 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);
 
             return machine.RaiseEvent(context);
         }
@@ -2156,9 +1770,7 @@
         /// <param name="context11">An additional context added to the event context</param>
         /// <param name="context12">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this T machine,
-            TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5,
-            T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2178,19 +1790,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);
 
             return machine.RaiseEvent(context);
         }
@@ -2218,9 +1818,7 @@
         /// <param name="context11">An additional context added to the event context</param>
         /// <param name="context12">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this T machine,
-            TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4,
-            T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2237,28 +1835,14 @@
             where T11 : class
             where T12 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -2281,9 +1865,7 @@
         /// <param name="context12">An additional context added to the event context</param>
         /// <param name="context13">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this T machine,
-            TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
-            T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2304,20 +1886,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);
 
             return machine.RaiseEvent(context);
         }
@@ -2344,9 +1913,7 @@
         /// <param name="context12">An additional context added to the event context</param>
         /// <param name="context13">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this T machine,
-            TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
-            T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2364,25 +1931,11 @@
             where T12 : class
             where T13 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);
 
             return machine.RaiseEvent(context);
         }
@@ -2411,9 +1964,7 @@
         /// <param name="context12">An additional context added to the event context</param>
         /// <param name="context13">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this T machine,
-            TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5,
-            T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2434,20 +1985,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);
 
             return machine.RaiseEvent(context);
         }
@@ -2476,9 +2014,7 @@
         /// <param name="context12">An additional context added to the event context</param>
         /// <param name="context13">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this T machine,
-            TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4,
-            T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2496,29 +2032,14 @@
             where T12 : class
             where T13 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -2542,9 +2063,7 @@
         /// <param name="context13">An additional context added to the event context</param>
         /// <param name="context14">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this T machine,
-            TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
-            T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2566,21 +2085,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
-            context.GetOrAddPayload(() => context14);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);            context.GetOrAddPayload(() => context14);
 
             return machine.RaiseEvent(context);
         }
@@ -2608,9 +2113,7 @@
         /// <param name="context13">An additional context added to the event context</param>
         /// <param name="context14">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this T machine,
-            TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
-            T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2629,26 +2132,11 @@
             where T13 : class
             where T14 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
-            context.GetOrAddPayload(() => context14);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);            context.GetOrAddPayload(() => context14);
 
             return machine.RaiseEvent(context);
         }
@@ -2678,9 +2166,7 @@
         /// <param name="context13">An additional context added to the event context</param>
         /// <param name="context14">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this T machine,
-            TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5,
-            T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2702,21 +2188,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
-            context.GetOrAddPayload(() => context14);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);            context.GetOrAddPayload(() => context14);
 
             return machine.RaiseEvent(context);
         }
@@ -2746,10 +2218,7 @@
         /// <param name="context13">An additional context added to the event context</param>
         /// <param name="context14">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this T machine,
-            TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4,
-            T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13,
-            T14 context14,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2768,30 +2237,14 @@
             where T13 : class
             where T14 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
-            context.GetOrAddPayload(() => context14);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);            context.GetOrAddPayload(() => context14);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -2816,9 +2269,7 @@
         /// <param name="context14">An additional context added to the event context</param>
         /// <param name="context15">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this T machine,
-            TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
-            T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14, T15 context15,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14, T15 context15,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2841,22 +2292,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
-            context.GetOrAddPayload(() => context14);
-            context.GetOrAddPayload(() => context15);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);            context.GetOrAddPayload(() => context14);            context.GetOrAddPayload(() => context15);
 
             return machine.RaiseEvent(context);
         }
@@ -2885,9 +2321,7 @@
         /// <param name="context14">An additional context added to the event context</param>
         /// <param name="context15">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this T machine,
-            TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
-            T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14, T15 context15,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14, T15 context15,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2907,27 +2341,11 @@
             where T14 : class
             where T15 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
-            context.GetOrAddPayload(() => context14);
-            context.GetOrAddPayload(() => context15);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);            context.GetOrAddPayload(() => context14);            context.GetOrAddPayload(() => context15);
 
             return machine.RaiseEvent(context);
         }
@@ -2958,10 +2376,7 @@
         /// <param name="context14">An additional context added to the event context</param>
         /// <param name="context15">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this T machine,
-            TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5,
-            T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14,
-            T15 context15,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14, T15 context15,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -2984,22 +2399,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
-            context.GetOrAddPayload(() => context14);
-            context.GetOrAddPayload(() => context15);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);            context.GetOrAddPayload(() => context14);            context.GetOrAddPayload(() => context15);
 
             return machine.RaiseEvent(context);
         }
@@ -3030,10 +2430,7 @@
         /// <param name="context14">An additional context added to the event context</param>
         /// <param name="context15">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this T machine,
-            TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4,
-            T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13,
-            T14 context14, T15 context15,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14, T15 context15,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -3053,31 +2450,14 @@
             where T14 : class
             where T15 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
-            context.GetOrAddPayload(() => context14);
-            context.GetOrAddPayload(() => context15);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);            context.GetOrAddPayload(() => context14);            context.GetOrAddPayload(() => context15);
 
             return machine.RaiseEvent(context);
         }
-
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -3103,10 +2483,7 @@
         /// <param name="context15">An additional context added to the event context</param>
         /// <param name="context16">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this T machine,
-            TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7,
-            T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14, T15 context15,
-            T16 context16,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16>(this T machine, TInstance instance, Event @event, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14, T15 context15, T16 context16,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -3130,23 +2507,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
-            context.GetOrAddPayload(() => context14);
-            context.GetOrAddPayload(() => context15);
-            context.GetOrAddPayload(() => context16);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);            context.GetOrAddPayload(() => context14);            context.GetOrAddPayload(() => context15);            context.GetOrAddPayload(() => context16);
 
             return machine.RaiseEvent(context);
         }
@@ -3176,10 +2537,7 @@
         /// <param name="context15">An additional context added to the event context</param>
         /// <param name="context16">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this T machine,
-            TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6,
-            T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14, T15 context15,
-            T16 context16,
+        public static Task RaiseEvent<T, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16>(this T machine, TInstance instance, Func<T, Event> eventSelector, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14, T15 context15, T16 context16,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -3200,28 +2558,11 @@
             where T15 : class
             where T16 : class
         {
-            var @event = eventSelector(machine);
+            Event @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
-            context.GetOrAddPayload(() => context14);
-            context.GetOrAddPayload(() => context15);
-            context.GetOrAddPayload(() => context16);
+            var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);            context.GetOrAddPayload(() => context14);            context.GetOrAddPayload(() => context15);            context.GetOrAddPayload(() => context16);
 
             return machine.RaiseEvent(context);
         }
@@ -3253,10 +2594,7 @@
         /// <param name="context15">An additional context added to the event context</param>
         /// <param name="context16">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
-            this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4,
-            T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13,
-            T14 context14, T15 context15, T16 context16,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16>(this T machine, TInstance instance, Event<TData> @event, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14, T15 context15, T16 context16,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -3280,23 +2618,7 @@
             if (@event == null)
                 throw new ArgumentNullException(nameof(@event));
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
-            context.GetOrAddPayload(() => context14);
-            context.GetOrAddPayload(() => context15);
-            context.GetOrAddPayload(() => context16);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);            context.GetOrAddPayload(() => context14);            context.GetOrAddPayload(() => context15);            context.GetOrAddPayload(() => context16);
 
             return machine.RaiseEvent(context);
         }
@@ -3328,10 +2650,7 @@
         /// <param name="context15">An additional context added to the event context</param>
         /// <param name="context16">An additional context added to the event context</param>
         /// <param name="cancellationToken"></param>
-        public static Task RaiseEvent<T, TData, TInstance, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
-            this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3,
-            T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12,
-            T13 context13, T14 context14, T15 context15, T16 context16,
+        public static Task RaiseEvent<T, TData, TInstance,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16>(this T machine, TInstance instance, Func<T, Event<TData>> eventSelector, TData data, T1 context1, T2 context2, T3 context3, T4 context4, T5 context5, T6 context6, T7 context7, T8 context8, T9 context9, T10 context10, T11 context11, T12 context12, T13 context13, T14 context14, T15 context15, T16 context16,
             CancellationToken cancellationToken = default(CancellationToken))
             where T : class, StateMachine, StateMachine<TInstance>
             where TInstance : class
@@ -3352,28 +2671,11 @@
             where T15 : class
             where T16 : class
         {
-            var @event = eventSelector(machine);
+            Event<TData> @event = eventSelector(machine);
             if (@event == null)
-                throw new ArgumentNullException(nameof(eventSelector),
-                    "The event selector did not return a valid event from the state machine");
+                throw new ArgumentNullException(nameof(eventSelector), "The event selector did not return a valid event from the state machine");
 
-            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
-            context.GetOrAddPayload(() => context1);
-            context.GetOrAddPayload(() => context2);
-            context.GetOrAddPayload(() => context3);
-            context.GetOrAddPayload(() => context4);
-            context.GetOrAddPayload(() => context5);
-            context.GetOrAddPayload(() => context6);
-            context.GetOrAddPayload(() => context7);
-            context.GetOrAddPayload(() => context8);
-            context.GetOrAddPayload(() => context9);
-            context.GetOrAddPayload(() => context10);
-            context.GetOrAddPayload(() => context11);
-            context.GetOrAddPayload(() => context12);
-            context.GetOrAddPayload(() => context13);
-            context.GetOrAddPayload(() => context14);
-            context.GetOrAddPayload(() => context15);
-            context.GetOrAddPayload(() => context16);
+            var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);            context.GetOrAddPayload(() => context1);            context.GetOrAddPayload(() => context2);            context.GetOrAddPayload(() => context3);            context.GetOrAddPayload(() => context4);            context.GetOrAddPayload(() => context5);            context.GetOrAddPayload(() => context6);            context.GetOrAddPayload(() => context7);            context.GetOrAddPayload(() => context8);            context.GetOrAddPayload(() => context9);            context.GetOrAddPayload(() => context10);            context.GetOrAddPayload(() => context11);            context.GetOrAddPayload(() => context12);            context.GetOrAddPayload(() => context13);            context.GetOrAddPayload(() => context14);            context.GetOrAddPayload(() => context15);            context.GetOrAddPayload(() => context16);
 
             return machine.RaiseEvent(context);
         }

--- a/src/Automatonymous/RaiseEventExtensions.tt
+++ b/src/Automatonymous/RaiseEventExtensions.tt
@@ -1,6 +1,7 @@
 ﻿<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ output extension="cs" #>
-<#@ assembly  name="System.Core" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
 namespace Automatonymous
 {
     using System;
@@ -32,8 +33,8 @@ namespace Automatonymous
             var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
 
             return machine.RaiseEvent(context);
-        }         
-        
+        }
+
         /// <summary>
         /// Raise a simple event on the state machine
         /// </summary>
@@ -55,8 +56,8 @@ namespace Automatonymous
             var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);
 
             return machine.RaiseEvent(context);
-        }  
-        
+        }
+
         /// <summary>
         /// Raise a data event on the state machine
         /// </summary>
@@ -79,8 +80,8 @@ namespace Automatonymous
             var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
 
             return machine.RaiseEvent(context);
-        }     
-               
+        }
+
         /// <summary>
         /// Raise a data event on the state machine
         /// </summary>
@@ -104,8 +105,8 @@ namespace Automatonymous
             var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);
 
             return machine.RaiseEvent(context);
-        }        
-         
+        }
+
 <#
     for (int i = 1; i <= 16; i++)
     {
@@ -140,7 +141,7 @@ namespace Automatonymous
             var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);<#
         for (int j = 1; j <= i; j++)
         {
-#> 
+#>
             context.GetOrAddPayload(() => context<#= j #>);<#
         }
 #>
@@ -172,7 +173,7 @@ namespace Automatonymous
             var context = new StateMachineEventContext<TInstance>(machine, instance, @event, cancellationToken);<#
         for (int j = 1; j <= i; j++)
         {
-#> 
+#>
             context.GetOrAddPayload(() => context<#= j #>);<#
         }
 #>
@@ -205,7 +206,7 @@ namespace Automatonymous
             var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);<#
         for (int j = 1; j <= i; j++)
         {
-#> 
+#>
             context.GetOrAddPayload(() => context<#= j #>);<#
         }
 #>
@@ -239,7 +240,7 @@ namespace Automatonymous
             var context = new StateMachineEventContext<TInstance, TData>(machine, instance, @event, data, cancellationToken);<#
         for (int j = 1; j <= i; j++)
         {
-#> 
+#>
             context.GetOrAddPayload(() => context<#= j #>);<#
         }
 #>

--- a/src/Automatonymous/StateMachineVisitor.cs
+++ b/src/Automatonymous/StateMachineVisitor.cs
@@ -5,21 +5,16 @@ namespace Automatonymous
 
     public interface StateMachineVisitor
     {
-        void Visit(State state, Action<State> next);
+        void Visit(State state, Action<State> next = null);
 
-        void Visit(Event @event, Action<Event> next);
+        void Visit(Event @event, Action<Event> next = null);
 
-        void Visit<TData>(Event<TData> @event, Action<Event<TData>> next);
+        void Visit<TData>(Event<TData> @event, Action<Event<TData>> next = null);
 
-        void Visit(Activity activity);
+        void Visit<T>(Behavior<T> behavior, Action<Behavior<T>> next = null);
 
-        void Visit<T>(Behavior<T> behavior);
+        void Visit<T, TData>(Behavior<T, TData> behavior, Action<Behavior<T, TData>> next = null);
 
-        void Visit<T>(Behavior<T> behavior, Action<Behavior<T>> next);
-
-        void Visit<T, TData>(Behavior<T, TData> behavior);
-        void Visit<T, TData>(Behavior<T, TData> behavior, Action<Behavior<T, TData>> next);
-
-        void Visit(Activity activity, Action<Activity> next);
+        void Visit(Activity activity, Action<Activity> next = null);
     }
 }

--- a/src/Automatonymous/States/StateMachineState.cs
+++ b/src/Automatonymous/States/StateMachineState.cs
@@ -49,10 +49,8 @@ namespace Automatonymous.States
             superState?.AddSubstate(this);
         }
 
-        public bool Equals(State other)
-        {
-            return string.CompareOrdinal(_name, other?.Name ?? "") == 0;
-        }
+        public bool Equals(State other) =>
+            string.CompareOrdinal(_name, other?.Name ?? "") == 0;
 
         public State<TInstance> SuperState { get; }
         public string Name => _name;

--- a/tests/Automatonymous.Tests/Combine_Specs.cs
+++ b/tests/Automatonymous.Tests/Combine_Specs.cs
@@ -10,7 +10,7 @@
         [Test]
         public async Task Should_have_called_combined_event()
         {
-            _machine = new TestStateMachine();
+            _machine = new TestStateMachine(false);
             _instance = new Instance();
             await _machine.RaiseEvent(_instance, _machine.Start);
 
@@ -23,7 +23,7 @@
         [Test]
         public async Task Should_not_call_for_one_event()
         {
-            _machine = new TestStateMachine();
+            _machine = new TestStateMachine(false);
             _instance = new Instance();
             await _machine.RaiseEvent(_instance, _machine.Start);
 
@@ -35,7 +35,44 @@
         [Test]
         public async Task Should_not_call_for_one_other_event()
         {
-            _machine = new TestStateMachine();
+            _machine = new TestStateMachine(false);
+            _instance = new Instance();
+            await _machine.RaiseEvent(_instance, _machine.Start);
+
+            await _machine.RaiseEvent(_instance, _machine.Second);
+
+            Assert.IsFalse(_instance.Called);
+        }
+
+        [Test]
+        public async Task Assigned_to_specific_state_should_have_called_combined_event()
+        {
+            _machine = new TestStateMachine(true);
+            _instance = new Instance();
+            await _machine.RaiseEvent(_instance, _machine.Start);
+
+            await _machine.RaiseEvent(_instance, _machine.First);
+            await _machine.RaiseEvent(_instance, _machine.Second);
+
+            Assert.IsTrue(_instance.Called);
+        }
+
+        [Test]
+        public async Task Assigned_to_specific_state_should_not_call_for_one_event()
+        {
+            _machine = new TestStateMachine(true);
+            _instance = new Instance();
+            await _machine.RaiseEvent(_instance, _machine.Start);
+
+            await _machine.RaiseEvent(_instance, _machine.First);
+
+            Assert.IsFalse(_instance.Called);
+        }
+
+        [Test]
+        public async Task Assigned_to_specific_state_should_not_call_for_one_other_event()
+        {
+            _machine = new TestStateMachine(true);
             _instance = new Instance();
             await _machine.RaiseEvent(_instance, _machine.Start);
 
@@ -59,9 +96,12 @@
         sealed class TestStateMachine :
             AutomatonymousStateMachine<Instance>
         {
-            public TestStateMachine()
+            public TestStateMachine(bool specificallyAssignedToWaiting)
             {
-                CompositeEvent(() => Third, x => x.CompositeStatus, First, Second);
+                if (specificallyAssignedToWaiting)
+                    CompositeEvent(() => Third, x => Equals(x, Waiting), x => x.CompositeStatus, First, Second);
+                else
+                    CompositeEvent(() => Third, x => x.CompositeStatus, First, Second);
 
                 Initially(
                     When(Start)
@@ -90,7 +130,7 @@
         [Test]
         public async Task Should_have_called_combined_event()
         {
-            _machine = new TestStateMachine();
+            _machine = new TestStateMachine(false);
             _instance = new Instance();
             await _machine.RaiseEvent(_instance, _machine.Start);
 
@@ -107,7 +147,7 @@
         [Test]
         public async Task Should_have_initial_state_with_zero()
         {
-            _machine = new TestStateMachine();
+            _machine = new TestStateMachine(false);
             _instance = new Instance();
             await _machine.RaiseEvent(_instance, _machine.Start);
 
@@ -117,7 +157,7 @@
         [Test]
         public async Task Should_not_call_for_one_event()
         {
-            _machine = new TestStateMachine();
+            _machine = new TestStateMachine(false);
             _instance = new Instance();
             await _machine.RaiseEvent(_instance, _machine.Start);
 
@@ -129,7 +169,58 @@
         [Test]
         public async Task Should_not_call_for_one_other_event()
         {
-            _machine = new TestStateMachine();
+            _machine = new TestStateMachine(false);
+            _instance = new Instance();
+            await _machine.RaiseEvent(_instance, _machine.Start);
+
+            await _machine.RaiseEvent(_instance, _machine.Second);
+
+            Assert.IsFalse(_instance.Called);
+        }
+
+        [Test]
+        public async Task Assigned_to_specific_state_should_have_called_combined_event()
+        {
+            _machine = new TestStateMachine(true);
+            _instance = new Instance();
+            await _machine.RaiseEvent(_instance, _machine.Start);
+
+            Assert.IsFalse(_instance.Called);
+
+            await _machine.RaiseEvent(_instance, _machine.First);
+            await _machine.RaiseEvent(_instance, _machine.Second);
+
+            Assert.IsTrue(_instance.Called);
+
+            Assert.AreEqual(2, _instance.CurrentState);
+        }
+
+        [Test]
+        public async Task Assigned_to_specific_state_should_have_initial_state_with_zero()
+        {
+            _machine = new TestStateMachine(true);
+            _instance = new Instance();
+            await _machine.RaiseEvent(_instance, _machine.Start);
+
+            Assert.AreEqual(3, _instance.CurrentState);
+        }
+
+        [Test]
+        public async Task Assigned_to_specific_state_should_not_call_for_one_event()
+        {
+            _machine = new TestStateMachine(true);
+            _instance = new Instance();
+            await _machine.RaiseEvent(_instance, _machine.Start);
+
+            await _machine.RaiseEvent(_instance, _machine.First);
+
+            Assert.IsFalse(_instance.Called);
+        }
+
+        [Test]
+        public async Task Assigned_to_specific_state_should_not_call_for_one_other_event()
+        {
+            _machine = new TestStateMachine(true);
             _instance = new Instance();
             await _machine.RaiseEvent(_instance, _machine.Start);
 
@@ -153,11 +244,14 @@
         sealed class TestStateMachine :
             AutomatonymousStateMachine<Instance>
         {
-            public TestStateMachine()
+            public TestStateMachine(bool specificallyAssignedToWaiting)
             {
                 InstanceState(x => x.CurrentState);
 
-                CompositeEvent(() => Third, x => x.CompositeStatus, First, Second);
+                if (specificallyAssignedToWaiting)
+                    CompositeEvent(() => Third, x => Equals(x, Waiting), x => x.CompositeStatus, First, Second);
+                else
+                    CompositeEvent(() => Third, x => x.CompositeStatus, First, Second);
 
                 Initially(
                     When(Start)

--- a/tests/Automatonymous.Tests/Visualizer_Specs.cs
+++ b/tests/Automatonymous.Tests/Visualizer_Specs.cs
@@ -19,13 +19,9 @@
         public void Should_show_the_goods()
         {
             var generator = new StateMachineGraphvizGenerator(_graph);
-
             string dots = generator.CreateDotFile();
-
             Console.WriteLine(dots);
-
             var expected = Expected.Replace("\r", "").Replace("\n", Environment.NewLine);
-
             Assert.AreEqual(expected, dots);
         }
 

--- a/tests/Automatonymous.Tests/Visualizer_Specs_CompositeEvent_Differences.cs
+++ b/tests/Automatonymous.Tests/Visualizer_Specs_CompositeEvent_Differences.cs
@@ -1,0 +1,122 @@
+﻿namespace Automatonymous.Tests
+{
+    using System;
+    using Graphing;
+    using NUnit.Framework;
+    using Visualizer;
+
+
+    [TestFixture]
+    public class Compare_difference_in_compositeevent_assignment
+    {
+        [Test]
+        public void Should_show_the_differences()
+        {
+            var dotsNotAssigned = new StateMachineGraphvizGenerator(new TestStateMachine(false).GetGraph()).CreateDotFile();
+            var dotsAssigned = new StateMachineGraphvizGenerator(new TestStateMachine(true).GetGraph()).CreateDotFile();
+            Console.WriteLine(dotsNotAssigned);
+            Console.WriteLine(dotsAssigned);
+            var expectedNotAssigned = ExpectedNotAssigned.Replace("\r", "").Replace("\n", Environment.NewLine);
+            var expectedAssigned = ExpectedAssigned.Replace("\r", "").Replace("\n", Environment.NewLine);
+            Assert.AreNotEqual(dotsNotAssigned, dotsAssigned);
+            Assert.AreEqual(expectedNotAssigned, dotsNotAssigned);
+            Assert.AreEqual(expectedAssigned, dotsAssigned);
+        }
+
+        const string ExpectedNotAssigned = @"digraph G {
+0 [shape=ellipse, label=""Initial""];
+1 [shape=ellipse, label=""Waiting""];
+2 [shape=ellipse, label=""Final""];
+3 [shape=rectangle, label=""Start""];
+4 [shape=rectangle, label=""First""];
+5 [shape=rectangle, label=""Third""];
+6 [shape=rectangle, label=""Second""];
+0 -> 3;
+1 -> 4;
+1 -> 6;
+2 -> 4;
+2 -> 6;
+3 -> 1;
+4 -> 5;
+5 -> 2;
+6 -> 5;
+}";
+
+        const string ExpectedAssigned = @"digraph G {
+0 [shape=ellipse, label=""Initial""];
+1 [shape=ellipse, label=""Waiting""];
+2 [shape=ellipse, label=""Final""];
+3 [shape=rectangle, label=""Start""];
+4 [shape=rectangle, label=""First""];
+5 [shape=rectangle, label=""Third""];
+6 [shape=rectangle, label=""Second""];
+0 -> 3;
+1 -> 4;
+1 -> 6;
+3 -> 1;
+4 -> 5;
+5 -> 2;
+6 -> 5;
+}";
+
+
+        class Instance
+        {
+            public CompositeEventStatus CompositeStatus { get; set; }
+            public bool Called { get; set; }
+            public bool CalledAfterAll { get; set; }
+            public State CurrentState { get; set; }
+            public bool SecondFirst { get; set; }
+            public bool First { get; set; }
+            public bool Second { get; set; }
+        }
+
+
+        sealed class TestStateMachine :
+            AutomatonymousStateMachine<Instance>
+        {
+            public TestStateMachine(bool specificallyAssignedToWaiting)
+            {
+                Initially(
+                    When(Start)
+                        .TransitionTo(Waiting));
+
+                During(Waiting,
+                    When(First)
+                        .Then(context =>
+                        {
+                            context.Instance.First = true;
+                            context.Instance.CalledAfterAll = false;
+                        }),
+                    When(Second)
+                        .Then(context =>
+                        {
+                            context.Instance.SecondFirst = !context.Instance.First;
+                            context.Instance.Second = true;
+                            context.Instance.CalledAfterAll = false;
+                        }),
+                    When(Third, context => context.Instance.SecondFirst)
+                        .Then(context =>
+                        {
+                            context.Instance.Called = true;
+                            context.Instance.CalledAfterAll = true;
+                        })
+                        .Finalize()
+                    );
+
+                if (specificallyAssignedToWaiting)
+                    CompositeEvent(() => Third, x => Equals(x, Waiting), x => x.CompositeStatus, First, Second);
+                else
+                    CompositeEvent(() => Third, x => x.CompositeStatus, First, Second);
+            }
+
+            public State Waiting { get; private set; }
+
+            public Event Start { get; private set; }
+
+            public Event First { get; private set; }
+            public Event Second { get; private set; }
+            public Event Third { get; private set; }
+        }
+    }
+}


### PR DESCRIPTION
This results in a cleaner graph when visualizing. Also, when visualizing the graph the edge between the state and composite event is skipped.

Originally the graph would be generated as:
| Graph | Visual |
| -------|---------|
|digraph G {<br>0 [shape=ellipse, label="Initial"];<br>1 [shape=ellipse, label="Waiting"];<br>2 [shape=ellipse, label="Final"];<br>3 [shape=rectangle, label="Start"];<br>4 [shape=rectangle, label="First"];<br>5 [shape=rectangle, label="Third"];<br>6 [shape=rectangle, label="Second"];<br>0 -> 3;<br>1 -> 4;<br>1 -> 6;<br>1 -> 5;<br>2 -> 4;<br>2 -> 6;<br>3 -> 1;<br>4 -> 5;<br>5 -> 2;<br>6 -> 5;<br>}|![image](https://user-images.githubusercontent.com/15146247/151675294-754eb586-2840-4e76-b2ef-3619d58b8b3d.png)|

Skipping the edge from the state to the composite event (in this case the arrow from 'Waiting' to 'Third') results in:

| Graph | Visual |
| -------|---------|
|digraph G {<br>0 [shape=ellipse, label="Initial"];<br>1 [shape=ellipse, label="Waiting"];<br>2 [shape=ellipse, label="Final"];<br>3 [shape=rectangle, label="Start"];<br>4 [shape=rectangle, label="First"];<br>5 [shape=rectangle, label="Third"];<br>6 [shape=rectangle, label="Second"];<br>0 -> 3;<br>1 -> 4;<br>1 -> 6;<br>2 -> 4;<br>2 -> 6;<br>3 -> 1;<br>4 -> 5;<br>5 -> 2;<br>6 -> 5;<br>}|![image](https://user-images.githubusercontent.com/15146247/151675397-32e05de5-cadc-4a70-bc00-ff3eb1dbc02e.png)|

When assigning the composite event 'Third' explicitly to the 'Waiting' state results in:

| Graph | Visual |
| -------|---------|
|digraph G {<br>0 [shape=ellipse, label="Initial"];<br>1 [shape=ellipse, label="Waiting"];<br>2 [shape=ellipse, label="Final"];<br>3 [shape=rectangle, label="Start"];<br>4 [shape=rectangle, label="First"];<br>5 [shape=rectangle, label="Third"];<br>6 [shape=rectangle, label="Second"];<br>0 -> 3;<br>1 -> 4;<br>1 -> 6;<br>3 -> 1;<br>4 -> 5;<br>5 -> 2;<br>6 -> 5;<br>}|![image](https://user-images.githubusercontent.com/15146247/151675460-67c90dca-c279-47fd-a4fd-de803caaad22.png)|

Note that when assigning a composite event to a state that it removes a number of 'weird' edges. In this case the edges between the Final and First and Second events. These transitions are not defined in the state machine itself but are added due to the way the composite event is registered.

The last image visualizes the state machine best as far as I am concerned. Only when the 'First' and 'Second' events have been handled will the 'Third' event be fired and will the state machine change state from 'Waiting' to 'Final'.

```C#
public TestStateMachine(bool specificallyAssignedToWaiting)
{
    Initially(
        When(Start)
            .TransitionTo(Waiting));

    During(Waiting,
        When(First)
            .Then(context =>
            {
                context.Instance.First = true;
                context.Instance.CalledAfterAll = false;
            }),
        When(Second)
            .Then(context =>
            {
                context.Instance.SecondFirst = !context.Instance.First;
                context.Instance.Second = true;
                context.Instance.CalledAfterAll = false;
            }),
        When(Third, context => context.Instance.SecondFirst)
            .Then(context =>
            {
                context.Instance.Called = true;
                context.Instance.CalledAfterAll = true;
            })
            .Finalize()
        );

    if (specificallyAssignedToWaiting)
        // Assigning the 'Third' event specifically to the 'Waiting' state
        CompositeEvent(() => Third, x => Equals(x, Waiting), x => x.CompositeStatus, First, Second);
    else
        CompositeEvent(() => Third, x => x.CompositeStatus, First, Second);
}
```