### PR TITLE
Should_raise_both_enter_events fails

### DIFF
--- a/tests/Automatonymous.Tests/SubStateOnEnter_Specs.cs
+++ b/tests/Automatonymous.Tests/SubStateOnEnter_Specs.cs
@@ -1,0 +1,77 @@
+﻿namespace Automatonymous.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class SubStateOnEnter_Specs
+    {
+        [Test]
+        public async Task Should_raise_both_enter_events()
+        {
+            var instance = new StateData();
+            var machine = new StateMachine();
+            var observer = new StateChangeObserver<StateData>();
+            var eventObserver = new EventRaisedObserver<StateData>();
+
+            using var subscription = machine.ConnectStateObserver(observer);
+            using var beforeEnterSub = machine.ConnectEventObserver(machine.s2.Enter, eventObserver);
+
+            await machine.RaiseEvent(instance, machine.Start); // go to s1
+            await machine.RaiseEvent(instance, machine.Boom); // go to s2
+            await machine.RaiseEvent(instance, machine.ToSub); // s2 does not handle ToSub
+            await machine.RaiseEvent(instance, machine.Boom); // go to s1
+            await machine.RaiseEvent(instance, machine.ToSub); // go to s21 --> Enter s2 is missing here!
+            await machine.RaiseEvent(instance, machine.Quit);
+
+            Assert.That(eventObserver.Events.Count, Is.EqualTo(2));
+        }
+
+
+        public class StateData 
+        {
+            public string CurrentSate { get; set; }
+        }
+
+
+        public class StateMachine :
+            AutomatonymousStateMachine<StateData>
+        {
+            public StateMachine()
+            {
+                InstanceState(x => x.CurrentSate);
+
+                SubState(() => s21, s2);
+
+                Initially(When(Start).TransitionTo(s1));
+
+                WhenEnterAny(x => x.Then(context => Console.WriteLine($"Enter {context.Instance.CurrentSate} ({context.Event.Name}).")));
+                WhenLeaveAny(x => x.Then(context => Console.WriteLine($"Leave {context.Instance.CurrentSate} ({context.Event.Name}).")));
+
+                During(s1,
+                    When(Boom).TransitionTo(s2),
+                    When(ToSub).TransitionTo(s21)
+                );
+                During(s2,
+                    When(Boom).TransitionTo(s1)
+                );
+
+                DuringAny(When(Quit).Finalize());
+
+                Finally(x => x.Then(context => Console.WriteLine("We're done.")));
+
+                OnUnhandledEvent(context => Console.Out.WriteLineAsync($"{context.Instance.CurrentSate} does not handle {context.Event}!"));
+            }
+
+            public State s1 { get; private set; }
+            public State s2 { get; private set; }
+            public State s21 { get; private set; }
+
+            public Event Start { get; private set; }
+            public Event Boom { get; private set; }
+            public Event ToSub { get; private set; }
+            public Event Quit { get; private set; }
+        }
+    }
+}


### PR DESCRIPTION
@phatboyg 
Just want to point out, that the unit test (with small adjustments) from
https://github.com/phatboyg/MassTransit/commit/80511d062d3f10b2ef605b767c011b784bfa580f
is actually failing here, which shows my original problem in
https://github.com/MassTransit/MassTransit/issues/3134

I can see that this is fixed in MassTransit v8. But since I wanted to use Automatonymous independently in an app not actually using MassTransit (I just a need a good state machine engine, nothing else), I think that integrating MassTransit v8 just for the state machine would be wrong and probably confusing (`MassTransitStateMachine` seems to be very very entangled with Sags etc.).

As I understood you, the problem will not be fixed in this repo. Since the unit test passes with Automatonymous 5.0.2, I am asking myself if using this version could be a solution for me.